### PR TITLE
Add flake8 to pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,23 +15,29 @@ strategy:
     Python37:
       python.version: '3.7'
 
+variables:
+  PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
+
 steps:
 - task: UsePythonVersion@0
   inputs:
     versionSpec: '$(python.version)'
   displayName: 'Use Python $(python.version)'
-
+- task: Cache@2
+  inputs:
+    key: 'python | "$(Agent.OS)" | requirements.txt'
+    restoreKeys: |
+      python | "$(Agent.OS)"
+      python
+    path: $(PIP_CACHE_DIR)
+  displayName: Cache pip packages
 - script: |
     python -m pip install --upgrade pip
-    pip install numpy==1.19.1 tensorflow==2.3.0 azureml-sdk[notebooks,automl]==1.13.0 glob2==0.7 imgaug==0.4.0
+    pip install numpy==1.19.1 tensorflow==2.3.0 azureml-sdk[notebooks,automl]==1.13.0 glob2==0.7 imgaug==0.4.0 flake8==3.8.4 pytest pytest-azurepipelines
   displayName: 'Install dependencies'
-
 - script: |
-    pip install flake8==3.8.4
     flake8
   displayName: 'flake8'
-
 - script: |
-    pip install pytest pytest-azurepipelines
     pytest
   displayName: 'pytest'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,6 +27,11 @@ steps:
   displayName: 'Install dependencies'
 
 - script: |
+    pip install flake8==3.8.4
+    flake8
+  displayName: 'flake8'
+
+- script: |
     pip install pytest pytest-azurepipelines
     pytest
   displayName: 'pytest'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,7 +36,7 @@ steps:
     pip install numpy==1.19.1 tensorflow==2.3.0 azureml-sdk[notebooks,automl]==1.13.0 glob2==0.7 imgaug==0.4.0 flake8==3.8.4 pytest pytest-azurepipelines
   displayName: 'Install dependencies'
 - script: |
-    flake8
+    flake8 src/
   displayName: 'flake8'
 - script: |
     pytest

--- a/src/common/zscore/ZscoreWeb/script.py
+++ b/src/common/zscore/ZscoreWeb/script.py
@@ -1,5 +1,8 @@
-from flask import *
+from flask import Flask, request, render_template
+
 from cgmzscore import Calculator
+
+
 app = Flask(__name__)
 
 

--- a/src/common/zscore/cgmzscore/__init__.py
+++ b/src/common/zscore/cgmzscore/__init__.py
@@ -1,0 +1,2 @@
+from .cgmzscore import Calculator  # noqa: F401
+from .cgmzscore import Chart  # noqa: F401

--- a/src/common/zscore/cgmzscore/__init__.py
+++ b/src/common/zscore/cgmzscore/__init__.py
@@ -1,2 +1,0 @@
-from .cgmzscore import Calculator
-from .cgmzscore import Chart

--- a/src/common/zscore/cgmzscore/test_cgmzscore.py
+++ b/src/common/zscore/cgmzscore/test_cgmzscore.py
@@ -1,7 +1,6 @@
 '''
 # Test case from data provide in survey of https://www.who.int/childgrowth/software/
 '''
-import pytest
 from cgmzscore import Calculator
 import pandas as pd
 import os
@@ -9,18 +8,20 @@ import os
 module_dir = str(os.path.split(os.path.abspath(__file__))[0])
 
 
-df = pd.read_csv(module_dir+'/test_data/test_data.csv')
+df = pd.read_csv(module_dir + '/test_data/test_data.csv')
 
 # 1 for male
 # 2 for female
 
-def check_null(i,df):
-    return pd.isnull(df.loc[i, 'WEIGHT']) or pd.isnull(df.loc[i, '_agedays']) or pd.isnull(df.loc[i, '_ZWEI']) or df.loc[i, '_agedays'] == 0 or pd.isnull(df.loc[i, '_ZLEN']) or pd.isnull(df.loc[i, '_ZWFL'])
+
+def check_null(i, df):
+    return pd.isnull(df.loc[i, 'WEIGHT']) or pd.isnull(df.loc[i, '_agedays']) or pd.isnull(
+        df.loc[i, '_ZWEI']) or df.loc[i, '_agedays'] == 0 or pd.isnull(df.loc[i, '_ZLEN']) or pd.isnull(df.loc[i, '_ZWFL'])
 
 
 def test_zScore_wfa():
     for i in range(len(df)):
-        if check_null(i,df):
+        if check_null(i, df):
             continue
 
         sex = 'M' if df['GENDER'][i] == 1 else 'F'
@@ -34,7 +35,7 @@ def test_zScore_wfa():
 
 def test_zScore_lhfa():
     for i in range(len(df)):
-        if check_null(i,df):
+        if check_null(i, df):
             continue
 
         sex = 'M' if df['GENDER'][i] == 1 else 'F'
@@ -52,7 +53,7 @@ def test_zScore_lhfa():
 
 def test_zScore_wfh():
     for i in range(len(df)):
-        if check_null(i,df):
+        if check_null(i, df):
             continue
 
         sex = 'M' if df['GENDER'][i] == 1 else 'F'
@@ -69,7 +70,7 @@ def test_zScore_wfh():
 
 def test_zScore_wfl():
     for i in range(len(df)):
-        if check_null(i,df):
+        if check_null(i, df):
             continue
 
         sex = 'M' if df['GENDER'][i] == 1 else 'F'

--- a/src/common/zscore/cgmzscore/test_cgmzscore.py
+++ b/src/common/zscore/cgmzscore/test_cgmzscore.py
@@ -1,9 +1,11 @@
 '''
 # Test case from data provide in survey of https://www.who.int/childgrowth/software/
 '''
-from cgmzscore import Calculator
-import pandas as pd
 import os
+
+import pandas as pd
+
+from cgmzscore import Calculator
 
 module_dir = str(os.path.split(os.path.abspath(__file__))[0])
 

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifact-plaincnn-height/src/test/test_preprocessing.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifact-plaincnn-height/src/test/test_preprocessing.py
@@ -7,7 +7,7 @@ import tensorflow as tf
 
 sys.path.append(str(Path(__file__).parents[1]))
 
-from config import DATA_AUGMENTATION_SAME_PER_CHANNEL, DATA_AUGMENTATION_DIFFERENT_EACH_CHANNEL, DATA_AUGMENTATION_NO
+from config import DATA_AUGMENTATION_SAME_PER_CHANNEL, DATA_AUGMENTATION_DIFFERENT_EACH_CHANNEL, DATA_AUGMENTATION_NO  # noqa: E402
 from preprocessing import augmentation, tf_augment_sample, sample_systematic_from_artifacts, sample_windows_from_artifacts, REGEX_PICKLE  # noqa: E402
 
 

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/test/test_preprocessing.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/test/test_preprocessing.py
@@ -6,7 +6,7 @@ import tensorflow as tf
 
 sys.path.append(str(Path(__file__).parents[1]))
 
-from config import DATA_AUGMENTATION_SAME_PER_CHANNEL, DATA_AUGMENTATION_DIFFERENT_EACH_CHANNEL, DATA_AUGMENTATION_NO
+from config import DATA_AUGMENTATION_SAME_PER_CHANNEL, DATA_AUGMENTATION_DIFFERENT_EACH_CHANNEL, DATA_AUGMENTATION_NO  # noqa: E402
 from preprocessing import augmentation, tf_augment_sample, sample_systematic_from_artifacts, sample_windows_from_artifacts, REGEX_PICKLE  # noqa: E402
 
 


### PR DESCRIPTION
**Motivation:** `flake8` checks that code is linted according to the common Python [PEP](https://www.python.org/dev/peps/pep-0008/) rules. By adding this to our CI pipeline we keep the code linted correctly.

**Changes:**
- add flake8 lint check to our pipeline
- resolve few flake8 errors

Future work:
- speed up (currently 3min18sec) the build by improve caching of azure pipeline