### PR TITLE
Bugfix REPO_DIR

### DIFF
--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/src/constants.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/src/constants.py
@@ -1,3 +1,3 @@
 from pathlib import Path
 
-REPO_DIR = Path(__file__).parents[5].absolute()
+REPO_DIR = Path(__file__).parents[6].absolute()

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifact-plaincnn-height/src/constants.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifact-plaincnn-height/src/constants.py
@@ -1,3 +1,3 @@
 from pathlib import Path
 
-REPO_DIR = Path(__file__).parents[5].absolute()
+REPO_DIR = Path(__file__).parents[6].absolute()

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/constants.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/constants.py
@@ -1,3 +1,3 @@
 from pathlib import Path
 
-REPO_DIR = Path(__file__).parents[5].absolute()
+REPO_DIR = Path(__file__).parents[6].absolute()


### PR DESCRIPTION
**Motivation**
During https://github.com/Welthungerhilfe/cgm-ml/pull/104, we restructured the repository.
In this process REPO_DIR became broken. 

**Implementation**
This is the fix such that REPO_DIR is in the root of the repository again