### PR TITLE
Adjust Model Evaluation to multiartifact (Functional API)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,4 @@ addopts = -p no:warnings
 testpaths =
     src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/test
     src/common/zscore/cgmzscore
+    src/common/eval

--- a/src/common/eval/Evaluate_models.ipynb
+++ b/src/common/eval/Evaluate_models.ipynb
@@ -4,7 +4,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Evaluate a trained model"
+    "# Evaluate a trained model\n",
+    "\n",
+    "Setup for tqdm widgets: https://ipywidgets.readthedocs.io/en/stable/user_install.html#installing-the-jupyterlab-extension"
    ]
   },
   {
@@ -45,7 +47,11 @@
     "\n",
     "sys.path.append(str(Path(os.getcwd()).parent / 'src'))\n",
     "\n",
-    "from eval_utils import calculate_performance, CODE_TO_SCANTYPE, CONFIG, REPO_DIR, preprocess_targets, preprocess_depthmap, tf_load_pickle, preprocess, extract_qrcode, extract_scantype, avgerror"
+    "latefusion_path = 'src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src'\n",
+    "sys.path.append(str(REPO_DIR / latefusion_path))\n",
+    "\n",
+    "from eval_utils import calculate_performance, CODE_TO_SCANTYPE, CONFIG, REPO_DIR, preprocess_targets, preprocess_depthmap, tf_load_pickle, preprocess, extract_qrcode, extract_scantype, avgerror\n",
+    "from preprocessing import create_multiartifact_sample, create_multiartifact_paths"
    ]
   },
   {
@@ -53,6 +59,17 @@
    "metadata": {},
    "source": [
     "### Select the  model to be evaluated from workspace"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(REPO_DIR)\n",
+    "DATA_DIR = REPO_DIR / 'data' if Run.get_context().id.startswith(\"OfflineRun\") else Path(\".\")\n",
+    "print(DATA_DIR)"
    ]
   },
   {
@@ -108,20 +125,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(REPO_DIR)\n",
-    "DATA_DIR = REPO_DIR / 'data' if Run.get_context().id.startswith(\"OfflineRun\") else Path(\".\")\n",
-    "print(DATA_DIR)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# MODEL_PATH = 'evaluation_95k_30082020/q3-depthmap-plaincnn-height-100-95k/run_03/outputs/best_model.h5'\n",
     "MODEL_PATH = model_fpath\n",
-    "\n",
     "model = load_model(MODEL_PATH)\n",
     "# summarize model.\n",
     "# model.summary()"
@@ -140,7 +144,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# paths = '../testdepthmap1/1585551618-hlby208u8z/pc_1585551618-hlby208u8z_1593156356859_100_000.p'\n",
     "paths = DATA_DIR / \"anon-depthmap-testset/scans/1585551618-hlby208u8z/100/pc_1585551618-hlby208u8z_1593156356859_100_000.p\"\n",
     "\n",
     "depthmap, targets = pickle.load(open(paths, \"rb\"))\n",
@@ -191,40 +194,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "qrcode_paths = glob2.glob(DATASET_PATH); qrcode_paths[:3]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "qrcode_paths = qrcode_paths[:10]  # reduce size for DEBUG speed"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "latefusion_path = 'src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src'\n",
-    "sys.path.append(str(REPO_DIR / latefusion_path))\n",
-    "from preprocessing import create_multiartifact_sample, create_multiartifact_paths"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "def create_samples(qrcode_paths: List[str]) -> List[List[str]]:\n",
     "    samples = []\n",
-    "    for qrcode_path_training in sorted(qrcode_paths):\n",
+    "    for qrcode_path in sorted(qrcode_paths):\n",
     "        for code in CONFIG.CODES_FOR_POSE_AND_SCANSTEP:\n",
-    "            p = os.path.join(qrcode_path_training, code)\n",
+    "            p = os.path.join(qrcode_path, code)\n",
     "            new_samples = create_multiartifact_paths(p, CONFIG.N_ARTIFACTS)\n",
     "            samples.extend(new_samples)\n",
     "    return samples"
@@ -236,10 +210,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "qrcode_paths = glob2.glob(DATASET_PATH); \n",
+    "print(len(qrcode_paths))\n",
+    "qrcode_paths = qrcode_paths  #[:100]  # reduce size for DEBUG speed\n",
+    "qrcode_paths[:3]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "samples_paths = create_samples(qrcode_paths)\n",
     "\n",
     "predictions = []\n",
-    "for sample_paths in samples_paths:\n",
+    "for sample_paths in tqdm(samples_paths):\n",
     "    depthmap, targets = create_multiartifact_sample(sample_paths)\n",
     "    depthmaps = tf.stack([depthmap])\n",
     "#     depthmap.set_shape((CONFIG.IMAGE_TARGET_HEIGHT, CONFIG.IMAGE_TARGET_WIDTH, CONFIG.N_ARTIFACTS))\n",
@@ -260,7 +246,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "predictions[0]"
+    "# 4.2 minutes for all 1745 scans' predictions\n",
+    "\n",
+    "# predictions[0]"
    ]
   },
   {
@@ -271,7 +259,7 @@
    "source": [
     "# Put predictions into dataframe\n",
     "df = pd.DataFrame([])\n",
-    "for i in tqdm(range(len(predictions))):\n",
+    "for i in range(len(predictions)):\n",
     "    label = np.array(predictions[i][3]).flatten()\n",
     "    data = pd.DataFrame({\n",
     "        'qrcode': predictions[i][0],\n",
@@ -384,6 +372,7 @@
     "df = calculate_performance(code, MAE)\n",
     "full_model_name = complete_name + CODE_TO_SCANTYPE[code]\n",
     "df.rename(index={0:full_model_name}, inplace=True)\n",
+    "df = df.round(2)\n",
     "display(HTML(df.to_html()))\n",
     "dfs.append(df)"
    ]
@@ -403,7 +392,6 @@
    "source": [
     "result = pd.concat(dfs)\n",
     "result.index.name = 'Model_Scantype'\n",
-    "result = result.round(2)\n",
     "result"
    ]
   },
@@ -418,13 +406,6 @@
     "Path(CSV_OUT_PATH.parent).mkdir(parents=True, exist_ok=True)\n",
     "result.to_csv(CSV_OUT_PATH, index=True)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/src/common/eval/Evaluate_models.ipynb
+++ b/src/common/eval/Evaluate_models.ipynb
@@ -4,13 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Evaluate a trained model\n",
-    "\n",
-    "## Setup\n",
-    "\n",
-    "```\n",
-    "jupyter nbextension enable --py widgetsnbextension\n",
-    "```"
+    "# Evaluate a trained model"
    ]
   },
   {
@@ -27,10 +21,12 @@
     "import pickle\n",
     "import shutil\n",
     "import sys\n",
+    "from typing import List\n",
     "\n",
     "import azureml.core\n",
-    "from azureml.core import Workspace\n",
+    "from azureml.core import Experiment, Workspace\n",
     "from azureml.core.dataset import Dataset\n",
+    "from azureml.core.run import Run\n",
     "import glob2\n",
     "import numpy as np\n",
     "import pandas as pd\n",
@@ -67,9 +63,15 @@
    "source": [
     "workspace = Workspace.from_config()\n",
     "\n",
-    "selected_experiments = [\"q3-depthmap-plaincnn-height-95k\"]\n",
-    "RUN_ID = 'q3-depthmap-plaincnn-height-95k_1597988908_42c4ef33'  # Run3\n",
-    "OUTPUT_DIR = 'data/logs/q3-depthmap-plaincnn-height-95k/run_03/'"
+    "# RUN_ID = 'q3-depthmapmultiartifactlatefusion-plaincnn-height-95k_1602505687_740ed7c4'\n",
+    "# RUN_NUMBER = 39\n",
+    "# Currently still training\n",
+    "\n",
+    "RUN_ID = 'q3-depthmapmultiartifact-plaincnn-height-95k_1599638940_e8c96832'\n",
+    "EXPERIMENT = \"_\".join(RUN_ID.split('_')[:-2])\n",
+    "RUN_NUMBER = 6\n",
+    "\n",
+    "OUTPUT_DIR = f'data/logs/q3-depthmapmultiartifact-plaincnn-height-95k/run_{RUN_NUMBER}/'"
    ]
   },
   {
@@ -77,6 +79,20 @@
    "metadata": {},
    "source": [
     "### Download the models on your local system for evaluation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Download pretrained model\n",
+    "print(f\"Downloading model from {RUN_ID}\")\n",
+    "previous_experiment = Experiment(workspace=workspace, name=EXPERIMENT)\n",
+    "previous_run = Run(previous_experiment, RUN_ID)\n",
+    "model_fpath = DATA_DIR / \"pretrained\" / RUN_ID / \"best_model.h5\"\n",
+    "previous_run.download_file(\"outputs/best_model.h5\", model_fpath)"
    ]
   },
   {
@@ -92,7 +108,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "REPO_DIR"
+    "print(REPO_DIR)\n",
+    "DATA_DIR = REPO_DIR / 'data' if Run.get_context().id.startswith(\"OfflineRun\") else Path(\".\")\n",
+    "print(DATA_DIR)"
    ]
   },
   {
@@ -102,7 +120,7 @@
    "outputs": [],
    "source": [
     "# MODEL_PATH = 'evaluation_95k_30082020/q3-depthmap-plaincnn-height-100-95k/run_03/outputs/best_model.h5'\n",
-    "MODEL_PATH = str(REPO_DIR / \"data/outputs/best_model_Run3_nodropout.h5\")\n",
+    "MODEL_PATH = model_fpath\n",
     "\n",
     "model = load_model(MODEL_PATH)\n",
     "# summarize model.\n",
@@ -123,7 +141,7 @@
    "outputs": [],
    "source": [
     "# paths = '../testdepthmap1/1585551618-hlby208u8z/pc_1585551618-hlby208u8z_1593156356859_100_000.p'\n",
-    "paths = REPO_DIR / \"data/anon-depthmap-testset/scans/1585551618-hlby208u8z/100/pc_1585551618-hlby208u8z_1593156356859_100_000.p\"\n",
+    "paths = DATA_DIR / \"anon-depthmap-testset/scans/1585551618-hlby208u8z/100/pc_1585551618-hlby208u8z_1593156356859_100_000.p\"\n",
     "\n",
     "depthmap, targets = pickle.load(open(paths, \"rb\"))\n",
     "depthmap = preprocess_depthmap(depthmap)\n",
@@ -157,7 +175,7 @@
    "outputs": [],
    "source": [
     "# DATASET_PATH = '/mnt/depthmap/depthmap_testset/scans/*/*/'\n",
-    "DATASET_PATH = str(REPO_DIR / \"data/anon-depthmap-testset/scans/*/*/\")"
+    "DATASET_PATH = str(DATA_DIR / \"anon-depthmap-testset/scans/*/\")"
    ]
   },
   {
@@ -173,7 +191,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "prediction_folder = glob2.glob(DATASET_PATH); prediction_folder[:3]"
+    "qrcode_paths = glob2.glob(DATASET_PATH); qrcode_paths[:3]"
    ]
   },
   {
@@ -182,22 +200,67 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "prediction_folder = prediction_folder[:10]  # reduce size for DEBUG speed\n",
+    "qrcode_paths = qrcode_paths[:10]  # reduce size for DEBUG speed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "latefusion_path = 'src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src'\n",
+    "sys.path.append(str(REPO_DIR / latefusion_path))\n",
+    "from preprocessing import create_multiartifact_sample, create_multiartifact_paths"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_samples(qrcode_paths: List[str]) -> List[List[str]]:\n",
+    "    samples = []\n",
+    "    for qrcode_path_training in sorted(qrcode_paths):\n",
+    "        for code in CONFIG.CODES_FOR_POSE_AND_SCANSTEP:\n",
+    "            p = os.path.join(qrcode_path_training, code)\n",
+    "            new_samples = create_multiartifact_paths(p, CONFIG.N_ARTIFACTS)\n",
+    "            samples.extend(new_samples)\n",
+    "    return samples"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "samples_paths = create_samples(qrcode_paths)\n",
     "\n",
     "predictions = []\n",
-    "for qrcode in tqdm(prediction_folder):\n",
-    "    depthmaps_pred = []\n",
-    "    labels = []\n",
-    "    depthfiles = []\n",
-    "    depthmaps = glob2.glob(qrcode + '/*.p')\n",
-    "    for files in depthmaps:\n",
-    "        depths, targets = preprocess(files)\n",
-    "        depthmaps_pred.append(depths)\n",
-    "        labels.append(targets)\n",
-    "        depthfiles.append(files)\n",
-    "    files_to_predict = tf.stack(depthmaps_pred)\n",
-    "    inference = model.predict(files_to_predict)\n",
-    "    predictions.append([qrcode, depthfiles,np.squeeze(inference), labels])"
+    "for sample_paths in samples_paths:\n",
+    "    depthmap, targets = create_multiartifact_sample(sample_paths)\n",
+    "    depthmaps = tf.stack([depthmap])\n",
+    "#     depthmap.set_shape((CONFIG.IMAGE_TARGET_HEIGHT, CONFIG.IMAGE_TARGET_WIDTH, CONFIG.N_ARTIFACTS))\n",
+    "#     targets.set_shape((len(CONFIG.TARGET_INDEXES,)))\n",
+    "    pred = model.predict(depthmaps)\n",
+    "\n",
+    "    qrcode = sample_paths[0].split('/')[-3]\n",
+    "    \n",
+    "    predictions.append([qrcode, sample_paths[0], float(np.squeeze(pred)), targets[0]])\n",
+    "    \n",
+    "# ValueError: Input 0 of layer sequential is incompatible with the layer: expected axis -1 of input shape \n",
+    "#             to have value 8 but received input with shape [None, 240, 180, 5]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "predictions[0]"
    ]
   },
   {
@@ -211,10 +274,10 @@
     "for i in tqdm(range(len(predictions))):\n",
     "    label = np.array(predictions[i][3]).flatten()\n",
     "    data = pd.DataFrame({\n",
-    "        'qrcode':predictions[i][0],\n",
+    "        'qrcode': predictions[i][0],\n",
     "        'artifacts': predictions[i][1],\n",
-    "        'predicted':predictions[i][2],\n",
-    "        'GT':label,\n",
+    "        'predicted': predictions[i][2],\n",
+    "        'GT': label,\n",
     "    })\n",
     "    df = df.append(data)\n",
     "df.head()"
@@ -226,8 +289,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df['qrcode'] = df.apply(extract_qrcode, axis=1)\n",
-    "df.head()"
+    "df['artifacts'].iloc[1]  # sample of how the artifacts path looks like for me, modify it accordingly to suit your path dependency"
    ]
   },
   {
@@ -236,7 +298,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df['artifacts'].iloc[1]  # sample of how the artifacts path looks like for me, modify it accordingly to suit your path dependency"
+    "len(df)"
    ]
   },
   {
@@ -318,12 +380,12 @@
    "outputs": [],
    "source": [
     "dfs = []\n",
-    "for code in CODE_TO_SCANTYPE.keys():\n",
-    "    df = calculate_performance(code, MAE)\n",
-    "    full_model_name = complete_name + CODE_TO_SCANTYPE[code]\n",
-    "    df.rename(index={0:full_model_name}, inplace=True)\n",
-    "    display(HTML(df.to_html()))\n",
-    "    dfs.append(df)"
+    "code = '100'\n",
+    "df = calculate_performance(code, MAE)\n",
+    "full_model_name = complete_name + CODE_TO_SCANTYPE[code]\n",
+    "df.rename(index={0:full_model_name}, inplace=True)\n",
+    "display(HTML(df.to_html()))\n",
+    "dfs.append(df)"
    ]
   },
   {
@@ -352,10 +414,17 @@
    "outputs": [],
    "source": [
     "# Save the model results in csv file\n",
-    "CSV_OUT_PATH = REPO_DIR / 'data' / 'eval' / RUN_ID / 'result.csv'\n",
+    "CSV_OUT_PATH = DATA_DIR / 'eval' / RUN_ID / 'result.csv'\n",
     "Path(CSV_OUT_PATH.parent).mkdir(parents=True, exist_ok=True)\n",
     "result.to_csv(CSV_OUT_PATH, index=True)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/src/common/eval/Evaluate_models.ipynb
+++ b/src/common/eval/Evaluate_models.ipynb
@@ -212,7 +212,7 @@
    "source": [
     "qrcode_paths = glob2.glob(DATASET_PATH); \n",
     "print(len(qrcode_paths))\n",
-    "qrcode_paths = qrcode_paths  #[:100]  # reduce size for DEBUG speed\n",
+    "qrcode_paths = qrcode_paths[:100]  # reduce size for DEBUG speed\n",
     "qrcode_paths[:3]"
    ]
   },
@@ -222,22 +222,32 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "samples_paths = create_samples(qrcode_paths)\n",
-    "\n",
+    "samples_paths = create_samples(qrcode_paths)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "predictions = []\n",
     "for sample_paths in tqdm(samples_paths):\n",
     "    depthmap, targets = create_multiartifact_sample(sample_paths)\n",
     "    depthmaps = tf.stack([depthmap])\n",
-    "#     depthmap.set_shape((CONFIG.IMAGE_TARGET_HEIGHT, CONFIG.IMAGE_TARGET_WIDTH, CONFIG.N_ARTIFACTS))\n",
-    "#     targets.set_shape((len(CONFIG.TARGET_INDEXES,)))\n",
+    "    \n",
     "    pred = model.predict(depthmaps)\n",
-    "\n",
-    "    qrcode = sample_paths[0].split('/')[-3]\n",
     "    \n",
-    "    predictions.append([qrcode, sample_paths[0], float(np.squeeze(pred)), targets[0]])\n",
-    "    \n",
-    "# ValueError: Input 0 of layer sequential is incompatible with the layer: expected axis -1 of input shape \n",
-    "#             to have value 8 but received input with shape [None, 240, 180, 5]\n"
+    "    predictions.append([sample_paths[0], float(np.squeeze(pred)), targets[0]])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "preds"
    ]
   },
   {
@@ -248,7 +258,7 @@
    "source": [
     "# 4.2 minutes for all 1745 scans' predictions\n",
     "\n",
-    "# predictions[0]"
+    "predictions[0]"
    ]
   },
   {
@@ -257,18 +267,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Put predictions into dataframe\n",
-    "df = pd.DataFrame([])\n",
-    "for i in range(len(predictions)):\n",
-    "    label = np.array(predictions[i][3]).flatten()\n",
-    "    data = pd.DataFrame({\n",
-    "        'qrcode': predictions[i][0],\n",
-    "        'artifacts': predictions[i][1],\n",
-    "        'predicted': predictions[i][2],\n",
-    "        'GT': label,\n",
-    "    })\n",
-    "    df = df.append(data)\n",
-    "df.head()"
+    "# list to dataframe\n",
+    "df = pd.DataFrame(predictions, columns=['artifacts', 'predicted', 'GT'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# df.head(5)"
    ]
   },
   {
@@ -278,6 +287,26 @@
    "outputs": [],
    "source": [
     "df['artifacts'].iloc[1]  # sample of how the artifacts path looks like for me, modify it accordingly to suit your path dependency"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df['scantype'] = df.apply(extract_scantype, axis=1)\n",
+    "df['qrcode'] = df.apply(extract_qrcode, axis=1)\n",
+    "df['scantype'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.head(5)"
    ]
   },
   {
@@ -296,16 +325,6 @@
    "outputs": [],
    "source": [
     "len(df['qrcode'].unique()) ## total number of scans"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df['scantype'] = df.apply(extract_scantype, axis=1)\n",
-    "df['scantype'].value_counts()"
    ]
   },
   {
@@ -347,12 +366,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# unique name for the index values\n",
-    "model_name = 'q3-depthmap-plaincnn-height-100-95k'\n",
-    "run_no ='_front_run_03'\n",
-    "complete_name = model_name + run_no; complete_name"
-   ]
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -367,14 +381,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dfs = []\n",
     "code = '100'\n",
+    "\n",
+    "# unique name for the index values\n",
+    "model_name = 'q3-depthmap-plaincnn-height-100-95k'\n",
+    "run_no = f'{CODE_TO_SCANTYPE[code]}_run_{RUN_NUMBER}'\n",
+    "complete_name = model_name + run_no; complete_name\n",
+    "\n",
     "df = calculate_performance(code, MAE)\n",
     "full_model_name = complete_name + CODE_TO_SCANTYPE[code]\n",
     "df.rename(index={0:full_model_name}, inplace=True)\n",
     "df = df.round(2)\n",
-    "display(HTML(df.to_html()))\n",
-    "dfs.append(df)"
+    "display(HTML(df.to_html()))"
    ]
   },
   {
@@ -390,7 +408,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result = pd.concat(dfs)\n",
+    "result = pd.concat([df])\n",
     "result.index.name = 'Model_Scantype'\n",
     "result"
    ]
@@ -406,6 +424,13 @@
     "Path(CSV_OUT_PATH.parent).mkdir(parents=True, exist_ok=True)\n",
     "result.to_csv(CSV_OUT_PATH, index=True)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/src/common/eval/Evaluate_models.ipynb
+++ b/src/common/eval/Evaluate_models.ipynb
@@ -46,12 +46,22 @@
     "print(\"Azure ML SDK Version: \", azureml.core.VERSION)\n",
     "\n",
     "sys.path.append(str(Path(os.getcwd()).parent / 'src'))\n",
+    "from eval_utils import calculate_performance, CODE_TO_SCANTYPE, CONFIG, REPO_DIR, preprocess_targets, preprocess_depthmap, tf_load_pickle, preprocess, extract_qrcode, extract_scantype, avgerror\n",
     "\n",
     "latefusion_path = 'src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src'\n",
     "sys.path.append(str(REPO_DIR / latefusion_path))\n",
-    "\n",
-    "from eval_utils import calculate_performance, CODE_TO_SCANTYPE, CONFIG, REPO_DIR, preprocess_targets, preprocess_depthmap, tf_load_pickle, preprocess, extract_qrcode, extract_scantype, avgerror\n",
     "from preprocessing import create_multiartifact_sample, create_multiartifact_paths"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(REPO_DIR)\n",
+    "DATA_DIR = REPO_DIR / 'data' if Run.get_context().id.startswith(\"OfflineRun\") else Path(\".\")\n",
+    "print(DATA_DIR)"
    ]
   },
   {
@@ -67,27 +77,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(REPO_DIR)\n",
-    "DATA_DIR = REPO_DIR / 'data' if Run.get_context().id.startswith(\"OfflineRun\") else Path(\".\")\n",
-    "print(DATA_DIR)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "workspace = Workspace.from_config()\n",
     "\n",
-    "# RUN_ID = 'q3-depthmapmultiartifactlatefusion-plaincnn-height-95k_1602505687_740ed7c4'\n",
-    "# RUN_NUMBER = 39\n",
-    "# Currently still training\n",
+    "RUN_ID = 'q3-depthmapmultiartifactlatefusion-plaincnn-height-95k_1602505687_740ed7c4'\n",
+    "RUN_NUMBER = 39\n",
     "\n",
-    "RUN_ID = 'q3-depthmapmultiartifact-plaincnn-height-95k_1599638940_e8c96832'\n",
+    "# RUN_ID = 'q3-depthmapmultiartifact-plaincnn-height-95k_1599638940_e8c96832'\n",
+    "# RUN_NUMBER = 6\n",
+    "\n",
     "EXPERIMENT = \"_\".join(RUN_ID.split('_')[:-2])\n",
-    "RUN_NUMBER = 6\n",
-    "\n",
     "OUTPUT_DIR = f'data/logs/q3-depthmapmultiartifact-plaincnn-height-95k/run_{RUN_NUMBER}/'"
    ]
   },
@@ -104,12 +102,30 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Download pretrained model\n",
+    "# Download model\n",
     "print(f\"Downloading model from {RUN_ID}\")\n",
     "previous_experiment = Experiment(workspace=workspace, name=EXPERIMENT)\n",
     "previous_run = Run(previous_experiment, RUN_ID)\n",
-    "model_fpath = DATA_DIR / \"pretrained\" / RUN_ID / \"best_model.h5\"\n",
-    "previous_run.download_file(\"outputs/best_model.h5\", model_fpath)"
+    "model_fpath = DATA_DIR / \"pretrained\" / RUN_ID / \"best_model_weights.h5\"   # DEBUG TODO _weights\n",
+    "# previous_run.download_file(\"outputs/best_model.h5\", model_fpath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PRETRAINED_RUN = \"q3-depthmap-plaincnn-height-95k_1597988908_42c4ef33\"\n",
+    "PRETRAINED_EXPERIMENT = \"_\".join(RUN_ID.split('_')[:-2])\n",
+    "PRETRAINED_RUN_NUMBER = 3\n",
+    "\n",
+    "# Download pretrained model\n",
+    "# print(f\"Downloading model from {RUN_ID}\")\n",
+    "# previous_experiment = Experiment(workspace=workspace, name=EXPERIMENT)\n",
+    "# previous_run = Run(previous_experiment, RUN_ID)\n",
+    "pretrained_model_fpath = DATA_DIR / \"pretrained\" / PRETRAINED_RUN / \"best_model.h5\"\n",
+    "# previous_run.download_file(\"outputs/best_model.h5\", model_fpath)"
    ]
   },
   {
@@ -125,10 +141,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "MODEL_PATH = model_fpath\n",
-    "model = load_model(MODEL_PATH)\n",
+    "from model import create_base_cnn, create_head\n",
+    "\n",
+    "input_shape = (CONFIG.IMAGE_TARGET_HEIGHT, CONFIG.IMAGE_TARGET_WIDTH, 1)\n",
+    "model = create_base_cnn(input_shape, dropout=False)\n",
+    "\n",
+    "head_input_shape = (128 * CONFIG.N_ARTIFACTS,)\n",
+    "model = create_head(head_input_shape, dropout=False)\n",
+    "\n",
+    "model.load_weights(model_fpath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# pretrained_model = load_model(pretrained_model_fpath)\n",
+    "model = load_model(model_fpath)\n",
     "# summarize model.\n",
-    "# model.summary()"
+    "# model.summary()\n"
    ]
   },
   {

--- a/src/common/eval/Evaluate_models.ipynb
+++ b/src/common/eval/Evaluate_models.ipynb
@@ -82,9 +82,6 @@
     "RUN_ID = 'q3-depthmapmultiartifactlatefusion-plaincnn-height-95k_1602505687_740ed7c4'\n",
     "RUN_NUMBER = 39\n",
     "\n",
-    "# RUN_ID = 'q3-depthmapmultiartifact-plaincnn-height-95k_1599638940_e8c96832'\n",
-    "# RUN_NUMBER = 6\n",
-    "\n",
     "EXPERIMENT = \"_\".join(RUN_ID.split('_')[:-2])\n",
     "OUTPUT_DIR = f'data/logs/q3-depthmapmultiartifact-plaincnn-height-95k/run_{RUN_NUMBER}/'"
    ]
@@ -106,7 +103,7 @@
     "print(f\"Downloading model from {RUN_ID}\")\n",
     "previous_experiment = Experiment(workspace=workspace, name=EXPERIMENT)\n",
     "previous_run = Run(previous_experiment, RUN_ID)\n",
-    "model_fpath = DATA_DIR / \"pretrained\" / RUN_ID / \"best_model_weights.h5\"   # DEBUG TODO _weights\n",
+    "model_fpath = DATA_DIR / \"pretrained\" / RUN_ID / \"best_model.ckpt\"\n",
     "# previous_run.download_file(\"outputs/best_model.h5\", model_fpath)"
    ]
   },
@@ -116,16 +113,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "PRETRAINED_RUN = \"q3-depthmap-plaincnn-height-95k_1597988908_42c4ef33\"\n",
-    "PRETRAINED_EXPERIMENT = \"_\".join(RUN_ID.split('_')[:-2])\n",
-    "PRETRAINED_RUN_NUMBER = 3\n",
-    "\n",
-    "# Download pretrained model\n",
-    "# print(f\"Downloading model from {RUN_ID}\")\n",
-    "# previous_experiment = Experiment(workspace=workspace, name=EXPERIMENT)\n",
-    "# previous_run = Run(previous_experiment, RUN_ID)\n",
-    "pretrained_model_fpath = DATA_DIR / \"pretrained\" / PRETRAINED_RUN / \"best_model.h5\"\n",
-    "# previous_run.download_file(\"outputs/best_model.h5\", model_fpath)"
+    "# Debug with local model\n",
+    "# model_fpath = DATA_DIR / 'outputs' / \"best_model.ckpt\""
    ]
   },
   {
@@ -141,27 +130,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from model import create_base_cnn, create_head\n",
-    "\n",
-    "input_shape = (CONFIG.IMAGE_TARGET_HEIGHT, CONFIG.IMAGE_TARGET_WIDTH, 1)\n",
-    "model = create_base_cnn(input_shape, dropout=False)\n",
-    "\n",
-    "head_input_shape = (128 * CONFIG.N_ARTIFACTS,)\n",
-    "model = create_head(head_input_shape, dropout=False)\n",
-    "\n",
-    "model.load_weights(model_fpath)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# pretrained_model = load_model(pretrained_model_fpath)\n",
     "model = load_model(model_fpath)\n",
     "# summarize model.\n",
-    "# model.summary()\n"
+    "# model.summary()"
    ]
   },
   {
@@ -280,15 +251,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "preds"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "# 4.2 minutes for all 1745 scans' predictions\n",
     "\n",
     "predictions[0]"
@@ -395,13 +357,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -457,13 +412,6 @@
     "Path(CSV_OUT_PATH.parent).mkdir(parents=True, exist_ok=True)\n",
     "result.to_csv(CSV_OUT_PATH, index=True)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/src/common/eval/Evaluate_multiartifact_model.ipynb
+++ b/src/common/eval/Evaluate_multiartifact_model.ipynb
@@ -385,11 +385,20 @@
     "run_no = f'{CODE_TO_SCANTYPE[code]}_run_{RUN_NUMBER}'\n",
     "complete_name = EXPERIMENT + run_no; complete_name\n",
     "\n",
-    "df = calculate_performance(code, MAE)\n",
+    "df_out = calculate_performance(code, MAE)\n",
     "full_model_name = complete_name + CODE_TO_SCANTYPE[code]\n",
-    "df.rename(index={0:full_model_name}, inplace=True)\n",
-    "df = df.round(2)\n",
-    "display(HTML(df.to_html()))"
+    "df_out.rename(index={0:full_model_name}, inplace=True)\n",
+    "df_out = df_out.round(2)\n",
+    "display(HTML(df_out.to_html()))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df['artifacts'].iloc[0]"
    ]
   },
   {
@@ -405,7 +414,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result = pd.concat([df])\n",
+    "result = pd.concat([df_out])\n",
     "result.index.name = 'Model_Scantype'\n",
     "result"
    ]

--- a/src/common/eval/Evaluate_multiartifact_model.ipynb
+++ b/src/common/eval/Evaluate_multiartifact_model.ipynb
@@ -6,11 +6,7 @@
    "source": [
     "# Evaluate a trained model\n",
     "\n",
-    "## Setup\n",
-    "\n",
-    "```\n",
-    "jupyter nbextension enable --py widgetsnbextension\n",
-    "```"
+    "Setup for tqdm widgets: https://ipywidgets.readthedocs.io/en/stable/user_install.html#installing-the-jupyterlab-extension"
    ]
   },
   {
@@ -27,10 +23,12 @@
     "import pickle\n",
     "import shutil\n",
     "import sys\n",
+    "from typing import List\n",
     "\n",
     "import azureml.core\n",
-    "from azureml.core import Workspace\n",
+    "from azureml.core import Experiment, Workspace\n",
     "from azureml.core.dataset import Dataset\n",
+    "from azureml.core.run import Run\n",
     "import glob2\n",
     "import numpy as np\n",
     "import pandas as pd\n",
@@ -48,8 +46,22 @@
     "print(\"Azure ML SDK Version: \", azureml.core.VERSION)\n",
     "\n",
     "sys.path.append(str(Path(os.getcwd()).parent / 'src'))\n",
+    "from eval_utils import calculate_performance, CODE_TO_SCANTYPE, CONFIG, REPO_DIR, preprocess_targets, preprocess_depthmap, tf_load_pickle, preprocess, extract_qrcode, extract_scantype, avgerror\n",
     "\n",
-    "from eval_utils import calculate_performance, CODE_TO_SCANTYPE, CONFIG, REPO_DIR, preprocess_targets, preprocess_depthmap, tf_load_pickle, preprocess, extract_qrcode, extract_scantype, avgerror"
+    "latefusion_path = 'src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src'\n",
+    "sys.path.append(str(REPO_DIR / latefusion_path))\n",
+    "from preprocessing import create_multiartifact_sample, create_multiartifact_paths"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(REPO_DIR)\n",
+    "DATA_DIR = REPO_DIR / 'data' if Run.get_context().id.startswith(\"OfflineRun\") else Path(\".\")\n",
+    "print(DATA_DIR)"
    ]
   },
   {
@@ -67,9 +79,11 @@
    "source": [
     "workspace = Workspace.from_config()\n",
     "\n",
-    "selected_experiments = [\"q3-depthmap-plaincnn-height-95k\"]\n",
-    "RUN_ID = 'q3-depthmap-plaincnn-height-95k_1597988908_42c4ef33'  # Run3\n",
-    "OUTPUT_DIR = 'data/logs/q3-depthmap-plaincnn-height-95k/run_03/'"
+    "RUN_ID = 'q3-depthmapmultiartifactlatefusion-plaincnn-height-95k_1603027726_7c24275f'\n",
+    "RUN_NUMBER = 56\n",
+    "\n",
+    "EXPERIMENT = \"_\".join(RUN_ID.split('_')[:-2])\n",
+    "OUTPUT_DIR = f'data/logs/q3-depthmapmultiartifact-plaincnn-height-95k/run_{RUN_NUMBER}/'"
    ]
   },
   {
@@ -77,6 +91,30 @@
    "metadata": {},
    "source": [
     "### Download the models on your local system for evaluation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Download model\n",
+    "print(f\"Downloading model from {RUN_ID}\")\n",
+    "previous_experiment = Experiment(workspace=workspace, name=EXPERIMENT)\n",
+    "previous_run = Run(previous_experiment, RUN_ID)\n",
+    "model_fpath = DATA_DIR / \"pretrained\" / RUN_ID / \"best_model.ckpt\"\n",
+    "previous_run.download_files(\"outputs/best_model.ckpt\", model_fpath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Debug with local model\n",
+    "# model_fpath = DATA_DIR / 'outputs' / \"best_model.ckpt\""
    ]
   },
   {
@@ -92,7 +130,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "REPO_DIR"
+    "model_fpath"
    ]
   },
   {
@@ -101,10 +139,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# MODEL_PATH = 'evaluation_95k_30082020/q3-depthmap-plaincnn-height-100-95k/run_03/outputs/best_model.h5'\n",
-    "MODEL_PATH = str(REPO_DIR / \"data/outputs/best_model_Run3_nodropout.h5\")\n",
-    "\n",
-    "model = load_model(MODEL_PATH)\n",
+    "model = load_model(f'{model_fpath}/outputs/best_model.ckpt')\n",
     "# summarize model.\n",
     "# model.summary()"
    ]
@@ -122,8 +157,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# paths = '../testdepthmap1/1585551618-hlby208u8z/pc_1585551618-hlby208u8z_1593156356859_100_000.p'\n",
-    "paths = REPO_DIR / \"data/anon-depthmap-testset/scans/1585551618-hlby208u8z/100/pc_1585551618-hlby208u8z_1593156356859_100_000.p\"\n",
+    "paths = DATA_DIR / \"anon-depthmap-testset/scans/1585551618-hlby208u8z/100/pc_1585551618-hlby208u8z_1593156356859_100_000.p\"\n",
     "\n",
     "depthmap, targets = pickle.load(open(paths, \"rb\"))\n",
     "depthmap = preprocess_depthmap(depthmap)\n",
@@ -157,7 +191,7 @@
    "outputs": [],
    "source": [
     "# DATASET_PATH = '/mnt/depthmap/depthmap_testset/scans/*/*/'\n",
-    "DATASET_PATH = str(REPO_DIR / \"data/anon-depthmap-testset/scans/*/*/\")"
+    "DATASET_PATH = str(DATA_DIR / \"anon-depthmap-testset/scans/*/\")"
    ]
   },
   {
@@ -173,7 +207,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "prediction_folder = glob2.glob(DATASET_PATH); prediction_folder[:3]"
+    "def create_samples(qrcode_paths: List[str]) -> List[List[str]]:\n",
+    "    samples = []\n",
+    "    for qrcode_path in sorted(qrcode_paths):\n",
+    "        for code in CONFIG.CODES_FOR_POSE_AND_SCANSTEP:\n",
+    "            p = os.path.join(qrcode_path, code)\n",
+    "            new_samples = create_multiartifact_paths(p, CONFIG.N_ARTIFACTS)\n",
+    "            samples.extend(new_samples)\n",
+    "    return samples"
    ]
   },
   {
@@ -182,22 +223,35 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "prediction_folder = prediction_folder[:10]  # reduce size for DEBUG speed\n",
-    "\n",
+    "qrcode_paths = glob2.glob(DATASET_PATH); \n",
+    "print(len(qrcode_paths))\n",
+    "qrcode_paths = qrcode_paths#[:100]  # reduce size for DEBUG speed\n",
+    "qrcode_paths[:3]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "samples_paths = create_samples(qrcode_paths)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "predictions = []\n",
-    "for qrcode in tqdm(prediction_folder):\n",
-    "    depthmaps_pred = []\n",
-    "    labels = []\n",
-    "    depthfiles = []\n",
-    "    depthmaps = glob2.glob(qrcode + '/*.p')\n",
-    "    for files in depthmaps:\n",
-    "        depths, targets = preprocess(files)\n",
-    "        depthmaps_pred.append(depths)\n",
-    "        labels.append(targets)\n",
-    "        depthfiles.append(files)\n",
-    "    files_to_predict = tf.stack(depthmaps_pred)\n",
-    "    inference = model.predict(files_to_predict)\n",
-    "    predictions.append([qrcode, depthfiles,np.squeeze(inference), labels])"
+    "for sample_paths in tqdm(samples_paths):\n",
+    "    depthmap, targets = create_multiartifact_sample(sample_paths)\n",
+    "    depthmaps = tf.stack([depthmap])\n",
+    "    \n",
+    "    pred = model.predict(depthmaps)\n",
+    "    \n",
+    "    predictions.append([sample_paths[0], float(np.squeeze(pred)), targets[0]])"
    ]
   },
   {
@@ -206,18 +260,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Put predictions into dataframe\n",
-    "df = pd.DataFrame([])\n",
-    "for i in tqdm(range(len(predictions))):\n",
-    "    label = np.array(predictions[i][3]).flatten()\n",
-    "    data = pd.DataFrame({\n",
-    "        'qrcode':predictions[i][0],\n",
-    "        'artifacts': predictions[i][1],\n",
-    "        'predicted':predictions[i][2],\n",
-    "        'GT':label,\n",
-    "    })\n",
-    "    df = df.append(data)\n",
-    "df.head()"
+    "# 4.2 minutes for all 1745 scans' predictions\n",
+    "\n",
+    "predictions[0]"
    ]
   },
   {
@@ -226,8 +271,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df['qrcode'] = df.apply(extract_qrcode, axis=1)\n",
-    "df.head()"
+    "# list to dataframe\n",
+    "df = pd.DataFrame(predictions, columns=['artifacts', 'predicted', 'GT'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# df.head(5)"
    ]
   },
   {
@@ -245,7 +299,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "len(df['qrcode'].unique()) ## total number of scans"
+    "df['scantype'] = df.apply(extract_scantype, axis=1)\n",
+    "df['qrcode'] = df.apply(extract_qrcode, axis=1)\n",
+    "df['scantype'].value_counts()"
    ]
   },
   {
@@ -254,8 +310,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df['scantype'] = df.apply(extract_scantype, axis=1)\n",
-    "df['scantype'].value_counts()"
+    "df.head(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(df['qrcode'].unique()) ## total number of scans"
    ]
   },
   {
@@ -272,7 +345,7 @@
    "outputs": [],
    "source": [
     "MAE = df.groupby(['qrcode', 'scantype']).mean()\n",
-    "MAE"
+    "# MAE"
    ]
   },
   {
@@ -289,19 +362,7 @@
    "outputs": [],
    "source": [
     "MAE['error'] = MAE.apply(avgerror, axis=1)\n",
-    "MAE"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# unique name for the index values\n",
-    "model_name = 'q3-depthmap-plaincnn-height-100-95k'\n",
-    "run_no ='_front_run_03'\n",
-    "complete_name = model_name + run_no; complete_name"
+    "# MAE"
    ]
   },
   {
@@ -317,13 +378,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dfs = []\n",
-    "for code in CODE_TO_SCANTYPE.keys():\n",
-    "    df = calculate_performance(code, MAE)\n",
-    "    full_model_name = complete_name + CODE_TO_SCANTYPE[code]\n",
-    "    df.rename(index={0:full_model_name}, inplace=True)\n",
-    "    display(HTML(df.to_html()))\n",
-    "    dfs.append(df)"
+    "code = '100'\n",
+    "\n",
+    "# unique name for the index values\n",
+    "model_name = 'q3-depthmap-plaincnn-height-100-95k'\n",
+    "run_no = f'{CODE_TO_SCANTYPE[code]}_run_{RUN_NUMBER}'\n",
+    "complete_name = EXPERIMENT + run_no; complete_name\n",
+    "\n",
+    "df = calculate_performance(code, MAE)\n",
+    "full_model_name = complete_name + CODE_TO_SCANTYPE[code]\n",
+    "df.rename(index={0:full_model_name}, inplace=True)\n",
+    "df = df.round(2)\n",
+    "display(HTML(df.to_html()))"
    ]
   },
   {
@@ -339,9 +405,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result = pd.concat(dfs)\n",
+    "result = pd.concat([df])\n",
     "result.index.name = 'Model_Scantype'\n",
-    "result = result.round(2)\n",
     "result"
    ]
   },
@@ -352,10 +417,17 @@
    "outputs": [],
    "source": [
     "# Save the model results in csv file\n",
-    "CSV_OUT_PATH = REPO_DIR / 'data' / 'eval' / RUN_ID / 'result.csv'\n",
+    "CSV_OUT_PATH = DATA_DIR / 'eval' / RUN_ID / 'result.csv'\n",
     "Path(CSV_OUT_PATH.parent).mkdir(parents=True, exist_ok=True)\n",
     "result.to_csv(CSV_OUT_PATH, index=True)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/src/common/eval/eval_utils.py
+++ b/src/common/eval/eval_utils.py
@@ -32,6 +32,8 @@ CONFIG = dotdict(dict(
     IMAGE_TARGET_WIDTH=180,
     NORMALIZATION_VALUE=7.5,
     TARGET_INDEXES=[0],  # 0 is height, 1 is weight.
+    N_ARTIFACTS=5,
+    CODES_FOR_POSE_AND_SCANSTEP=("100", ),
 ))
 
 

--- a/src/common/eval/tests/test_eval_utils.py
+++ b/src/common/eval/tests/test_eval_utils.py
@@ -1,0 +1,48 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.append(str(Path(__file__).parents[1]))
+
+from eval_utils import avgerror, calculate_performance, extract_scantype, extract_qrcode  # noqa: E402
+
+
+QR_CODE_1 = "1585013006-yqwb95138e"
+QR_CODE_2 = "1555555555-yqqqqqqqqq"
+
+
+def prepare_df(df):
+    df['scantype'] = df.apply(extract_scantype, axis=1)
+    df['qrcode'] = df.apply(extract_qrcode, axis=1)
+    df = df.groupby(['qrcode', 'scantype']).mean()
+    df['error'] = df.apply(avgerror, axis=1)
+    return df
+
+
+def test_calculate_performance_100percent():
+    data = {
+        'artifacts': [
+            f'scans/{QR_CODE_1}/100/pc_{QR_CODE_1}_1591849321035_100_000.p',
+            f'scans/{QR_CODE_2}/100/pc_{QR_CODE_2}_1591849321035_100_000.p'],
+        'GT': [98.1, 98.9],
+        'predicted': [98.1, 98.9],
+    }
+    df = pd.DataFrame.from_dict(data)
+    df = prepare_df(df)
+    df_out = calculate_performance(code='100', df_mae=df)
+    assert (df_out[1.2] == 100.0).all()
+
+
+def test_calculate_performance_50percent():
+    data = {
+        'artifacts': [
+            f'scans/{QR_CODE_1}/100/pc_{QR_CODE_1}_1591849321035_100_000.p',
+            f'scans/{QR_CODE_2}/100/pc_{QR_CODE_2}_1591849321035_100_000.p'],
+        'GT': [98.1, 98.9],
+        'predicted': [98.1, 98.9 + 7],
+    }
+    df = pd.DataFrame.from_dict(data)
+    df = prepare_df(df)
+    df_out = calculate_performance(code='100', df_mae=df)
+    assert (df_out[1.2] == 50.0).all()

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/config.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/config.py
@@ -39,7 +39,7 @@ CONFIG = dotdict(dict(
     # PRETRAINED_RUN="q3-depthmap-plaincnn-height-95k_1600451633_cb44f6db",  # Run17 (baseline: min(val_mae)=2.21cm)
     PRETRAINED_RUN="q3-depthmap-plaincnn-height-95k_1597988908_42c4ef33",  # Run3 (baseline: min(val_mae)=1.96cm)
 
-    SHOULD_FREEZE_BASE=True,
+    SHOULD_FREEZE_BASE=False,
 ))
 
 CONFIG.PRETRAINED_EXPERIMENT = "_".join(CONFIG.PRETRAINED_RUN.split('_')[:-2])

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/config.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/config.py
@@ -18,6 +18,7 @@ DATASET_MODE_MOUNT = "dataset_mode_mount"
 CONFIG = dotdict(dict(
     DATASET_MODE=DATASET_MODE_DOWNLOAD,
     DATASET_NAME="anon-depthmap-95k",
+    DATASET_NAME_LOCAL="anon-depthmap-mini",
     SPLIT_SEED=0,
     IMAGE_TARGET_HEIGHT=240,
     IMAGE_TARGET_WIDTH=180,
@@ -29,7 +30,7 @@ CONFIG = dotdict(dict(
 
     # Parameters for dataset generation.
     TARGET_INDEXES=[0],  # 0 is height, 1 is weight.
-    N_ARTIFACTS=5,
+    N_ARTIFACTS=5,  # number of artifact in one sample of multiartifact approach
     CODES_FOR_POSE_AND_SCANSTEP=("100", ),
     N_REPEAT_DATASET=1,
     DATA_AUGMENTATION_MODE=DATA_AUGMENTATION_NO,

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/config.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/config.py
@@ -36,9 +36,10 @@ CONFIG = dotdict(dict(
     SAMPLING_STRATEGY=SAMPLING_STRATEGY_SYSTEMATIC,
     USE_DROPOUT=False,
 
-    PRETRAINED_EXPERIMENT="q3-depthmap-plaincnn-height-95k",
     # PRETRAINED_RUN="q3-depthmap-plaincnn-height-95k_1600451633_cb44f6db",  # Run17 (baseline: min(val_mae)=2.21cm)
     PRETRAINED_RUN="q3-depthmap-plaincnn-height-95k_1597988908_42c4ef33",  # Run3 (baseline: min(val_mae)=1.96cm)
 
     SHOULD_FREEZE_BASE=True,
 ))
+
+CONFIG.PRETRAINED_EXPERIMENT = "_".join(CONFIG.PRETRAINED_RUN.split('_')[:-2])

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/config.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/config.py
@@ -37,7 +37,7 @@ CONFIG = dotdict(dict(
     USE_DROPOUT=False,
 
     # PRETRAINED_RUN="q3-depthmap-plaincnn-height-95k_1600451633_cb44f6db",  # Run17 (baseline: min(val_mae)=2.21cm)
-    PRETRAINED_RUN="",  # Run3 (baseline: min(val_mae)=1.96cm)
+    PRETRAINED_RUN="q3-depthmap-plaincnn-height-95k_1597988908_42c4ef33",  # Run3 (baseline: min(val_mae)=1.96cm)
 
     SHOULD_FREEZE_BASE=False,
 ))

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/config.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/config.py
@@ -39,7 +39,7 @@ CONFIG = dotdict(dict(
     # PRETRAINED_RUN="q3-depthmap-plaincnn-height-95k_1600451633_cb44f6db",  # Run17 (baseline: min(val_mae)=2.21cm)
     PRETRAINED_RUN="q3-depthmap-plaincnn-height-95k_1597988908_42c4ef33",  # Run3 (baseline: min(val_mae)=1.96cm)
 
-    SHOULD_FREEZE_BASE=False,
+    SHOULD_FREEZE_BASE=True,
 ))
 
 CONFIG.PRETRAINED_EXPERIMENT = "_".join(CONFIG.PRETRAINED_RUN.split('_')[:-2])

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/config.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/config.py
@@ -37,7 +37,7 @@ CONFIG = dotdict(dict(
     USE_DROPOUT=False,
 
     # PRETRAINED_RUN="q3-depthmap-plaincnn-height-95k_1600451633_cb44f6db",  # Run17 (baseline: min(val_mae)=2.21cm)
-    PRETRAINED_RUN="q3-depthmap-plaincnn-height-95k_1597988908_42c4ef33",  # Run3 (baseline: min(val_mae)=1.96cm)
+    PRETRAINED_RUN="",  # Run3 (baseline: min(val_mae)=1.96cm)
 
     SHOULD_FREEZE_BASE=False,
 ))

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/constants.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/constants.py
@@ -1,4 +1,4 @@
 from pathlib import Path
 
 REPO_DIR = Path(__file__).parents[6].absolute()
-DATA_DIR_ONLINE_RUN = "/tmp/data/"
+DATA_DIR_ONLINE_RUN = Path("/tmp/data/")

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/model.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/model.py
@@ -6,7 +6,7 @@ def load_base_cgm_model(model_fpath, should_freeze=False):
     loaded_model = models.load_model(model_fpath)
 
     # cut off last layer (https://stackoverflow.com/a/59304656/5497962)
-    beheaded_model = models.Sequential()
+    beheaded_model = models.Sequential(name="base_model_beheaded")
     for layer in loaded_model.layers[:-1]:
         beheaded_model.add(layer)
 

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/model.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/model.py
@@ -5,7 +5,7 @@ def load_base_cgm_model(model_fpath, should_freeze=False):
     # load model
     loaded_model = models.load_model(model_fpath)
 
-    # cut off last layer
+    # cut off last layer (https://stackoverflow.com/a/59304656/5497962)
     beheaded_model = models.Sequential()
     for layer in loaded_model.layers[:-1]:
         beheaded_model.add(layer)

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/model.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/model.py
@@ -6,7 +6,7 @@ def load_base_cgm_model(model_fpath, should_freeze=False):
     loaded_model = models.load_model(model_fpath)
 
     # cut off last layer
-    _ = loaded_model._layers.pop()
+    _ = loaded_model._layers.pop()  # TODO debug
 
     if should_freeze:
         for layer in loaded_model._layers:
@@ -81,5 +81,5 @@ def create_head(input_shape, dropout):
     if dropout:
         model.add(layers.Dropout(0.2))
 
-    model.add(layers.Dense(1, activation="linear"))
+    model.add(layers.Dense(1, activation="linear", input_shape=input_shape))
     return model

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/model.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/model.py
@@ -68,7 +68,7 @@ def create_base_cnn(input_shape, dropout):
 
 
 def create_head(input_shape, dropout):
-    model = models.Sequential()
+    model = models.Sequential(name="head")
     model.add(layers.Dense(128, activation="relu"))
     if dropout:
         model.add(layers.Dropout(0.2))

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/model.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/model.py
@@ -71,7 +71,7 @@ def create_base_cnn(input_shape, dropout):
 
 def create_head(input_shape, dropout):
     model = models.Sequential(name="head")
-    model.add(layers.Dense(128, activation="relu"))
+    model.add(layers.Dense(128, activation="relu", input_shape=input_shape))
     if dropout:
         model.add(layers.Dropout(0.2))
 
@@ -83,5 +83,5 @@ def create_head(input_shape, dropout):
     if dropout:
         model.add(layers.Dropout(0.2))
 
-    model.add(layers.Dense(1, activation="linear", input_shape=input_shape))
+    model.add(layers.Dense(1, activation="linear"))
     return model

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/model.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/model.py
@@ -6,13 +6,15 @@ def load_base_cgm_model(model_fpath, should_freeze=False):
     loaded_model = models.load_model(model_fpath)
 
     # cut off last layer
-    _ = loaded_model._layers.pop()  # TODO debug
+    beheaded_model = models.Sequential()
+    for layer in loaded_model.layers[:-1]:
+        beheaded_model.add(layer)
 
     if should_freeze:
-        for layer in loaded_model._layers:
+        for layer in beheaded_model._layers:
             layer.trainable = False
 
-    return loaded_model
+    return beheaded_model
 
 
 def create_base_cnn(input_shape, dropout):

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/train.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/train.py
@@ -70,7 +70,7 @@ assert len(qrcode_paths) != 0
 random.seed(CONFIG.SPLIT_SEED)
 random.shuffle(qrcode_paths)
 split_index = int(len(qrcode_paths) * 0.8)
-qrcode_paths_training = qrcode_paths[:split_index]
+qrcode_paths_training = qrcode_paths[:split_index][:10]
 
 qrcode_paths_validate = qrcode_paths[split_index:]
 qrcode_paths_activation = random.choice(qrcode_paths_validate)
@@ -174,8 +174,8 @@ base_model = get_base_model()
 base_model.summary()
 
 # Create the head
-head_input_shape = (128 * CONFIG.N_ARTIFACTS,)
-head_model = create_head(head_input_shape, dropout=CONFIG.USE_CROPOUT)
+# head_input_shape = (128 * CONFIG.N_ARTIFACTS,)
+# head_model = create_head(head_input_shape, dropout=CONFIG.USE_CROPOUT)
 # head_model.summary()
 
 # Implement artifact flow through the same model
@@ -185,7 +185,7 @@ model_input = layers.Input(
 
 features_list = []
 for i in range(CONFIG.N_ARTIFACTS):
-    features_part = model_input[:, :, :, i:i + 1]
+    features_part = model_input[:, :, :, i:(i + 1)]
     features_part = base_model(features_part)
     features_list.append(features_part)
 
@@ -244,6 +244,15 @@ model.compile(
     loss="mse",
     metrics=["mae"]
 )
+
+# Reproducing the error:
+tmp_model_filepath = str(DATA_DIR / "outputs/tmpmodel.h5")
+model.save(tmp_model_filepath)
+tf.keras.models.load_model(tmp_model_filepath)
+
+
+# model.save_weights(tmp_model_filepath)
+# model.load_weights(tmp_model_filepath)
 
 # Train the model.
 model.fit(

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/train.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/train.py
@@ -70,7 +70,7 @@ assert len(qrcode_paths) != 0
 random.seed(CONFIG.SPLIT_SEED)
 random.shuffle(qrcode_paths)
 split_index = int(len(qrcode_paths) * 0.8)
-qrcode_paths_training = qrcode_paths[:split_index][:10]  # DEBUG
+qrcode_paths_training = qrcode_paths[:split_index][:10]
 
 qrcode_paths_validate = qrcode_paths[split_index:]
 qrcode_paths_activation = random.choice(qrcode_paths_validate)
@@ -172,7 +172,6 @@ def get_base_model():
 # Create the base model
 base_model = get_base_model()
 base_model.summary()
-
 assert base_model.output_shape == (None, 128)
 
 # Create the head
@@ -187,12 +186,12 @@ model_input = layers.Input(
 
 features_list = []
 for i in range(CONFIG.N_ARTIFACTS):
-    features_part = model_input[:, :, :, i:(i + 1)]
+    features_part = model_input[:, :, :, i:i + 1]
     features_part = base_model(features_part)
     features_list.append(features_part)
 
 concatenation = tf.keras.layers.concatenate(features_list, axis=-1)
-# model_output = layers.Dense(1, activation="linear")(concatenation)  # shape: (None,640)
+assert concatenation.shape.as_list() == tf.TensorShape((None, 128 * CONFIG.N_ARTIFACTS)).as_list()
 model_output = head_model(concatenation)
 
 model = models.Model(model_input, model_output)

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/train.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/train.py
@@ -247,15 +247,6 @@ model.compile(
     metrics=["mae"]
 )
 
-# Reproducing the error:
-tmp_model_filepath = str(DATA_DIR / "outputs/tmpmodel.h5")
-model.save(tmp_model_filepath)
-tf.keras.models.load_model(tmp_model_filepath)
-
-
-# model.save_weights(tmp_model_filepath)
-# model.load_weights(tmp_model_filepath)
-
 # Train the model.
 model.fit(
     dataset_training.batch(CONFIG.BATCH_SIZE),

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/train.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/train.py
@@ -226,11 +226,12 @@ tensorboard_callback = tf.keras.callbacks.TensorBoard(
 training_callbacks.append(tensorboard_callback)
 
 # Add checkpoint callback.
-best_model_path = str(DATA_DIR / 'outputs/best_model.h5')
+best_model_path = str(DATA_DIR / 'outputs/best_model_weights.h5')
 checkpoint_callback = tf.keras.callbacks.ModelCheckpoint(
     filepath=best_model_path,
     monitor="val_loss",
     save_best_only=True,
+    save_weights_only=True,
     verbose=1
 )
 training_callbacks.append(checkpoint_callback)

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/train.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/train.py
@@ -70,7 +70,7 @@ assert len(qrcode_paths) != 0
 random.seed(CONFIG.SPLIT_SEED)
 random.shuffle(qrcode_paths)
 split_index = int(len(qrcode_paths) * 0.8)
-qrcode_paths_training = qrcode_paths[:split_index][:10]
+qrcode_paths_training = qrcode_paths[:split_index][:10]  # DEBUG
 
 qrcode_paths_validate = qrcode_paths[split_index:]
 qrcode_paths_activation = random.choice(qrcode_paths_validate)

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/train.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/train.py
@@ -22,9 +22,8 @@ random.seed(CONFIG.SPLIT_SEED)
 # Get the current run.
 run = Run.get_context()
 
-DATA_DIR = REPO_DIR / 'data' if run.id.startswith("OfflineRun") else Path(DATA_DIR_ONLINE_RUN)
+DATA_DIR = REPO_DIR / 'data' if run.id.startswith("OfflineRun") else Path(".")
 print(f"DATA_DIR: {DATA_DIR}")
-DATA_DIR.mkdir(parents=True, exist_ok=True)
 
 # Offline run. Download the sample dataset and run locally. Still push results to Azure.
 if run.id.startswith("OfflineRun"):
@@ -52,7 +51,7 @@ else:
     if CONFIG.DATASET_MODE == DATASET_MODE_MOUNT:
         dataset_path = run.input_datasets["dataset"]
     elif CONFIG.DATASET_MODE == DATASET_MODE_DOWNLOAD:
-        dataset_path = get_dataset_path(DATA_DIR, dataset_name)
+        dataset_path = get_dataset_path(DATA_DIR_ONLINE_RUN, dataset_name)
         download_dataset(workspace, dataset_name, dataset_path)
     else:
         raise NameError(f"Unknown DATASET_MODE: {CONFIG.DATASET_MODE}")

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/train.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/train.py
@@ -229,7 +229,7 @@ tensorboard_callback = tf.keras.callbacks.TensorBoard(
 training_callbacks.append(tensorboard_callback)
 
 # Add checkpoint callback.
-best_model_path = str(DATA_DIR / 'outputs/best_model.h5')
+best_model_path = str(DATA_DIR / 'outputs/best_model.ckpt')
 checkpoint_callback = tf.keras.callbacks.ModelCheckpoint(
     filepath=best_model_path,
     monitor="val_loss",

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/train.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/train.py
@@ -35,7 +35,7 @@ if run.id.startswith("OfflineRun"):
     experiment = Experiment(workspace, "training-junkyard")
     run = experiment.start_logging(outputs=None, snapshot_directory=None)
 
-    dataset_name = "anon-depthmap-mini"
+    dataset_name = CONFIG.DATASET_NAME_LOCAL
     dataset_path = get_dataset_path(DATA_DIR, dataset_name)
     download_dataset(workspace, dataset_name, dataset_path)
 

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/train.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/train.py
@@ -69,7 +69,7 @@ assert len(qrcode_paths) != 0
 random.seed(CONFIG.SPLIT_SEED)
 random.shuffle(qrcode_paths)
 split_index = int(len(qrcode_paths) * 0.8)
-qrcode_paths_training = qrcode_paths[:split_index][:10]
+qrcode_paths_training = qrcode_paths[:split_index]
 
 qrcode_paths_validate = qrcode_paths[split_index:]
 qrcode_paths_activation = random.choice(qrcode_paths_validate)

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/train.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/train.py
@@ -27,7 +27,7 @@ print(f"DATA_DIR: {DATA_DIR}")
 DATA_DIR.mkdir(parents=True, exist_ok=True)
 
 # Offline run. Download the sample dataset and run locally. Still push results to Azure.
-if(run.id.startswith("OfflineRun")):
+if run.id.startswith("OfflineRun"):
     print("Running in offline mode...")
 
     # Access workspace.


### PR DESCRIPTION
Tackles https://dev.azure.com/cgmorg/ChildGrowthMonitor/_workitems/edit/38

Changes: 
- Fix: actually use model head, not just a single Dense layer
- Change output format from `.h5` to `.ckpt` (This is default suggestion for TF2, .h5 has caused error `h5py: "RuntimeError: Unable to create link (name already exists)"` https://github.com/tensorflow/tensorflow/issues/36650#issuecomment-585517731)
- Adjust `Evaluate_models.ipynb` to multiartifact
- Evaluate all test-data (prepare code using a bad performing model)
- Refactor creating dataframe in `Evaluate_models.ipynb`