### PR TITLE
Depthmap toolkit triangualtion into export obj added

### DIFF
--- a/src/common/depthmap_toolkit/convertpcd2depth.py
+++ b/src/common/depthmap_toolkit/convertpcd2depth.py
@@ -23,5 +23,5 @@ os.mkdir('output')
 os.mkdir('output/depth')
 copyfile(input + '/../camera_calibration.txt', 'output/camera_calibration.txt')
 for i in range(len(pcd)):
-    pcd2depth.process(input + '/../camera_calibration.txt', input + '/' + pcd[i], 'output/depth/' + pcd[i] + '.depth')
+    pcd2depth.process('camera_calibration.txt', input + '/' + pcd[i], 'output/depth/' + pcd[i] + '.depth')
 print('Data exported into folder output')

--- a/src/common/depthmap_toolkit/depthmap.py
+++ b/src/common/depthmap_toolkit/depthmap.py
@@ -9,7 +9,7 @@ import zipfile
 
 def export(type, filename):
     if type == 'obj':
-        utils.exportOBJ('export/' + filename)
+        utils.exportOBJ('export/' + filename, 1)
     if type == 'pcd':
         utils.exportPCD('export/' + filename)
 

--- a/src/common/depthmap_toolkit/depthmap.py
+++ b/src/common/depthmap_toolkit/depthmap.py
@@ -9,7 +9,7 @@ import zipfile
 
 def export(type, filename):
     if type == 'obj':
-        utils.exportOBJ('export/' + filename, 1)
+        utils.exportOBJ('export/' + filename, triangulate=True)
     if type == 'pcd':
         utils.exportPCD('export/' + filename)
 

--- a/src/common/depthmap_toolkit/utils.py
+++ b/src/common/depthmap_toolkit/utils.py
@@ -211,7 +211,7 @@ def parseConfidence(tx, ty):
 def parseData(filename):
     global width, height, depthScale, maxConfidence, data, position, rotation
     with open('data', 'rb') as file:
-        line = str(file.readline())[:-3]
+        line = str(file.readline())[:-1]
         header = line.split('_')
         res = header[0].split('x')
         width = int(res[0])

--- a/src/common/depthmap_toolkit/utils.py
+++ b/src/common/depthmap_toolkit/utils.py
@@ -108,7 +108,7 @@ def exportOBJ(filename, triangulate):
                     res = convert2Dto3DOriented(calibration[1], x, y, depth)
                     if res:
                         count = count + 1
-                        indices[x][y] = count # add index of written vertex into array
+                        indices[x][y] = count  # add index of written vertex into array
                         file.write('v ' + str(res[0]) + ' ' + str(res[1]) + ' ' + str(res[2]) + '\n')
 
         if triangulate:

--- a/src/common/depthmap_toolkit/utils.py
+++ b/src/common/depthmap_toolkit/utils.py
@@ -108,7 +108,7 @@ def exportOBJ(filename, triangulate):
                     res = convert2Dto3DOriented(calibration[1], x, y, depth)
                     if res:
                         count = count + 1
-                        indices[x][y] = count #add index of written vertex into array
+                        indices[x][y] = count # add index of written vertex into array
                         file.write('v ' + str(res[0]) + ' ' + str(res[1]) + ' ' + str(res[2]) + '\n')
 
         if triangulate:

--- a/src/common/depthmap_toolkit/utils.py
+++ b/src/common/depthmap_toolkit/utils.py
@@ -94,7 +94,8 @@ def convert3Dto2D(intrisics, x, y, z):
 
 #write obj
 
-
+#triangulate=True generates OBJ of type mesh
+#triangulate=False generates OBJ of type pointcloud
 def exportOBJ(filename, triangulate):
 
     count = 0
@@ -107,21 +108,28 @@ def exportOBJ(filename, triangulate):
                     res = convert2Dto3DOriented(calibration[1], x, y, depth)
                     if res:
                         count = count + 1
-                        indices[x][y] = count
+                        indices[x][y] = count #add index of written vertex into array
                         file.write('v ' + str(res[0]) + ' ' + str(res[1]) + ' ' + str(res[2]) + '\n')
 
         if triangulate:
             maxDiff = 0.2
             for x in range(2, width - 2):
                 for y in range(2, height - 2):
+                    #get depth of all points of 2 potential triangles
                     d00 = parseDepth(x, y)
                     d10 = parseDepth(x + 1, y)
                     d01 = parseDepth(x, y + 1)
                     d11 = parseDepth(x + 1, y + 1)
+
+                    #check if first triangle points have existing indices
                     if indices[x][y] > 0 and indices[x + 1][y] > 0 and indices[x][y + 1] > 0:
+                        #check if the triangle size is valid (to prevent generating triangle connecting child and background)
                         if abs(d00 - d10) + abs(d00 - d01) + abs(d10 - d01) < maxDiff:
                             file.write('f ' + str(int(indices[x][y])) + ' ' + str(int(indices[x + 1][y])) + ' ' + str(int(indices[x][y + 1])) + '\n')
+
+                    #check if second triangle points have existing indices
                     if indices[x + 1][y + 1] > 0 and indices[x + 1][y] > 0 and indices[x][y + 1] > 0:
+                        #check if the triangle size is valid (to prevent generating triangle connecting child and background)
                         if abs(d11 - d10) + abs(d11 - d01) + abs(d10 - d01) < maxDiff:
                             file.write('f ' + str(int(indices[x + 1][y + 1])) + ' ' + str(int(indices[x + 1][y])) + ' ' + str(int(indices[x][y + 1])) + '\n')
         print('Pointcloud exported into ' + filename)


### PR DESCRIPTION
# Description

This PR adds a simple triangulation into depthmap toolkit. Export OBJ feature now adds into OBJ file vertex indices which changes the OBJ format from pointcloud to mesh. This enables better visualization of the quality of the captured data (especially useful during testing new devices)

[User story](https://dev.azure.com/cgmorg/ChildGrowthMonitor/_workitems/edit/296)

# How Has This Been Tested?

Test was done by visualizing exported data. Steps to reproduce the test:
* python convertpcd2depth.py _path_to_folder_with_pcd_file_
* python toolkit.py output
* click on export OBJ
* open export/output0.obj in Blender or any another 3D editor