### PR TITLE
Fix: Only push when master or release

### DIFF
--- a/src/common/zscore/azure-pipelines.yml
+++ b/src/common/zscore/azure-pipelines.yml
@@ -4,6 +4,10 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/python
 
 trigger:
+  branches:
+    include:
+    - master
+    - releases/*
   paths:
     include:
     - src/commmon/zscore/*
@@ -12,8 +16,6 @@ pool:
   vmImage: 'ubuntu-latest'
 strategy:
   matrix:
-    Python36:
-      python.version: '3.6'
     Python37:
       python.version: '3.7'
 


### PR DESCRIPTION
**Bug**: I found that zscore pipeline runs unintendedly, e.g., https://github.com/Welthungerhilfe/cgm-ml/pull/125
Currently, every PR commit builds the pip packages.
The file trigger seems doesn't seem to work.

To improve the situation, let's only run this on master and releases. Also only run this once for 1 python version