### PR TITLE
Refactor multiartifactlatefusion experiment code

### DIFF
--- a/src/common/eval/Evaluate_multiartifact_model.ipynb
+++ b/src/common/eval/Evaluate_multiartifact_model.ipynb
@@ -11,9 +11,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 55,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Azure ML SDK Version:  1.13.0\n"
+     ]
+    }
+   ],
    "source": [
     "%reload_ext autoreload\n",
     "%autoreload 2\n",
@@ -46,7 +54,7 @@
     "print(\"Azure ML SDK Version: \", azureml.core.VERSION)\n",
     "\n",
     "sys.path.append(str(Path(os.getcwd()).parent / 'src'))\n",
-    "from eval_utils import calculate_performance, CODE_TO_SCANTYPE, CONFIG, REPO_DIR, preprocess_targets, preprocess_depthmap, tf_load_pickle, preprocess, extract_qrcode, extract_scantype, avgerror\n",
+    "from eval_utils import calculate_performance, CODE_TO_SCANTYPE, CONFIG, MODEL_CKPT_FILENAME, REPO_DIR, preprocess_targets, preprocess_depthmap, tf_load_pickle, preprocess, extract_qrcode, extract_scantype, avgerror\n",
     "\n",
     "latefusion_path = 'src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src'\n",
     "sys.path.append(str(REPO_DIR / latefusion_path))\n",
@@ -103,8 +111,8 @@
     "print(f\"Downloading model from {RUN_ID}\")\n",
     "previous_experiment = Experiment(workspace=workspace, name=EXPERIMENT)\n",
     "previous_run = Run(previous_experiment, RUN_ID)\n",
-    "model_fpath = DATA_DIR / \"pretrained\" / RUN_ID / \"best_model.ckpt\"\n",
-    "previous_run.download_files(\"outputs/best_model.ckpt\", model_fpath)"
+    "model_fpath = DATA_DIR / \"pretrained\" / RUN_ID / MODEL_CKPT_FILENAME\n",
+    "previous_run.download_files(f\"outputs/{MODEL_CKPT_FILENAME}\", model_fpath)"
    ]
   },
   {
@@ -114,7 +122,7 @@
    "outputs": [],
    "source": [
     "# Debug with local model\n",
-    "# model_fpath = DATA_DIR / 'outputs' / \"best_model.ckpt\""
+    "# model_fpath = DATA_DIR / 'outputs' / MODEL_CKPT_FILENAME"
    ]
   },
   {
@@ -139,7 +147,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = load_model(f'{model_fpath}/outputs/best_model.ckpt')\n",
+    "model = load_model(f'{model_fpath}/outputs/{MODEL_CKPT_FILENAME}')\n",
     "# summarize model.\n",
     "# model.summary()"
    ]

--- a/src/common/eval/eval_utils.py
+++ b/src/common/eval/eval_utils.py
@@ -9,6 +9,7 @@ REPO_DIR = Path(os.getcwd()).parents[2]
 
 # Error margin on various ranges
 EVALUATION_ACCURACIES = [.2, .4, .8, 1.2, 2., 2.5, 3., 4., 5., 6.]
+MODEL_CKPT_FILENAME = "best_model.ckpt"
 
 CODE_TO_SCANTYPE = {
     '100': '_front',

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/constants.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/constants.py
@@ -3,3 +3,4 @@ from pathlib import Path
 REPO_DIR = Path(__file__).parents[6].absolute()
 DATA_DIR_ONLINE_RUN = Path("/tmp/data/")
 MODEL_H5_FILENAME = "best_model.h5"
+MODEL_CKPT_FILENAME = "best_model.ckpt"

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/constants.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/constants.py
@@ -2,3 +2,4 @@ from pathlib import Path
 
 REPO_DIR = Path(__file__).parents[6].absolute()
 DATA_DIR_ONLINE_RUN = Path("/tmp/data/")
+MODEL_H5_FILENAME = "best_model.h5"

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/model.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/model.py
@@ -8,27 +8,24 @@ from tensorflow.keras import models, layers
 from config import CONFIG
 
 
-workspace = Workspace.from_config()
-
-
-def download_pretrained_model(output_model_fpath: str):
-    print(f"Downloading pretrained model from {CONFIG.PRETRAINED_RUN}")
-    previous_experiment = Experiment(workspace=workspace, name=CONFIG.PRETRAINED_EXPERIMENT)
-    previous_run = Run(previous_experiment, CONFIG.PRETRAINED_RUN)
-    previous_run.download_file("outputs/best_model.h5", output_model_fpath)
-
-
-def get_base_model(data_dir: Path) -> models.Sequential:
+def get_base_model(workspace: Workspace, data_dir: Path) -> models.Sequential:
     if CONFIG.PRETRAINED_RUN:
         model_fpath = data_dir / "pretrained/" / CONFIG.PRETRAINED_RUN / "best_model.h5"
         if not os.path.exists(model_fpath):
-            download_pretrained_model(model_fpath)
+            download_pretrained_model(workspace, model_fpath)
         print(f"Loading pretrained model from {model_fpath}")
         base_model = load_base_cgm_model(model_fpath, should_freeze=CONFIG.SHOULD_FREEZE_BASE)
     else:
         input_shape = (CONFIG.IMAGE_TARGET_HEIGHT, CONFIG.IMAGE_TARGET_WIDTH, 1)
         base_model = create_base_cnn(input_shape, dropout=CONFIG.USE_DROPOUT)  # output_shape: (128,)
     return base_model
+
+
+def download_pretrained_model(workspace: Workspace, output_model_fpath: str):
+    print(f"Downloading pretrained model from {CONFIG.PRETRAINED_RUN}")
+    previous_experiment = Experiment(workspace=workspace, name=CONFIG.PRETRAINED_EXPERIMENT)
+    previous_run = Run(previous_experiment, CONFIG.PRETRAINED_RUN)
+    previous_run.download_file("outputs/best_model.h5", output_model_fpath)
 
 
 def load_base_cgm_model(model_fpath: str, should_freeze: bool=False) -> models.Sequential:

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/model.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/model.py
@@ -1,7 +1,37 @@
+import os
+from pathlib import Path
+
+from azureml.core import Experiment, Workspace
+from azureml.core.run import Run
 from tensorflow.keras import models, layers
 
+from config import CONFIG
 
-def load_base_cgm_model(model_fpath, should_freeze=False):
+
+workspace = Workspace.from_config()
+
+
+def download_pretrained_model(output_model_fpath: str):
+    print(f"Downloading pretrained model from {CONFIG.PRETRAINED_RUN}")
+    previous_experiment = Experiment(workspace=workspace, name=CONFIG.PRETRAINED_EXPERIMENT)
+    previous_run = Run(previous_experiment, CONFIG.PRETRAINED_RUN)
+    previous_run.download_file("outputs/best_model.h5", output_model_fpath)
+
+
+def get_base_model(data_dir: Path) -> models.Sequential:
+    if CONFIG.PRETRAINED_RUN:
+        model_fpath = data_dir / "pretrained/" / CONFIG.PRETRAINED_RUN / "best_model.h5"
+        if not os.path.exists(model_fpath):
+            download_pretrained_model(model_fpath)
+        print(f"Loading pretrained model from {model_fpath}")
+        base_model = load_base_cgm_model(model_fpath, should_freeze=CONFIG.SHOULD_FREEZE_BASE)
+    else:
+        input_shape = (CONFIG.IMAGE_TARGET_HEIGHT, CONFIG.IMAGE_TARGET_WIDTH, 1)
+        base_model = create_base_cnn(input_shape, dropout=CONFIG.USE_DROPOUT)  # output_shape: (128,)
+    return base_model
+
+
+def load_base_cgm_model(model_fpath: str, should_freeze: bool=False) -> models.Sequential:
     # load model
     loaded_model = models.load_model(model_fpath)
 

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/model.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/model.py
@@ -6,11 +6,12 @@ from azureml.core.run import Run
 from tensorflow.keras import models, layers
 
 from config import CONFIG
+from constants import MODEL_H5_FILENAME
 
 
 def get_base_model(workspace: Workspace, data_dir: Path) -> models.Sequential:
     if CONFIG.PRETRAINED_RUN:
-        model_fpath = data_dir / "pretrained/" / CONFIG.PRETRAINED_RUN / "best_model.h5"
+        model_fpath = data_dir / "pretrained/" / CONFIG.PRETRAINED_RUN / MODEL_H5_FILENAME
         if not os.path.exists(model_fpath):
             download_pretrained_model(workspace, model_fpath)
         print(f"Loading pretrained model from {model_fpath}")
@@ -25,7 +26,7 @@ def download_pretrained_model(workspace: Workspace, output_model_fpath: str):
     print(f"Downloading pretrained model from {CONFIG.PRETRAINED_RUN}")
     previous_experiment = Experiment(workspace=workspace, name=CONFIG.PRETRAINED_EXPERIMENT)
     previous_run = Run(previous_experiment, CONFIG.PRETRAINED_RUN)
-    previous_run.download_file("outputs/best_model.h5", output_model_fpath)
+    previous_run.download_file(f"outputs/{MODEL_H5_FILENAME}", output_model_fpath)
 
 
 def load_base_cgm_model(model_fpath: str, should_freeze: bool=False) -> models.Sequential:

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/preprocessing.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/preprocessing.py
@@ -134,6 +134,16 @@ def py_load_pickle(path, max_value):
     return depthmap, targets
 
 
+def create_samples(qrcode_paths: List[str]) -> List[List[str]]:
+    samples = []
+    for qrcode_path in sorted(qrcode_paths):
+        for code in CONFIG.CODES_FOR_POSE_AND_SCANSTEP:
+            p = os.path.join(qrcode_path, code)
+            new_samples = create_multiartifact_paths(p, CONFIG.N_ARTIFACTS)
+            samples.extend(new_samples)
+    return samples
+
+
 def create_multiartifact_paths(qrcode_path: str, n_artifacts: int) -> List[List[str]]:
     """Look at files for 1 qrcode and divide into samples.
 

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/train.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/train.py
@@ -9,7 +9,7 @@ from azureml.core.run import Run
 from tensorflow.keras import callbacks, layers, models
 
 from config import CONFIG, DATASET_MODE_DOWNLOAD, DATASET_MODE_MOUNT
-from constants import DATA_DIR_ONLINE_RUN, REPO_DIR
+from constants import DATA_DIR_ONLINE_RUN, MODEL_CKPT_FILENAME, REPO_DIR
 from model import create_head, get_base_model
 from preprocessing import create_samples, tf_load_pickle, tf_augment_sample
 from utils import download_dataset, get_dataset_path, AzureLogCallback, create_tensorboard_callback
@@ -147,7 +147,7 @@ model_output = head_model(concatenation)
 model = models.Model(model_input, model_output)
 model.summary()
 
-best_model_path = str(DATA_DIR / 'outputs/best_model.ckpt')
+best_model_path = str(DATA_DIR / f'outputs/{MODEL_CKPT_FILENAME}')
 checkpoint_callback = callbacks.ModelCheckpoint(
     filepath=best_model_path,
     monitor="val_loss",

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/train.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/train.py
@@ -121,14 +121,13 @@ del dataset_norm
 
 
 # Create the base model
-base_model = get_base_model(DATA_DIR)
+base_model = get_base_model(workspace, DATA_DIR)
 base_model.summary()
 assert base_model.output_shape == (None, 128)
 
 # Create the head
 head_input_shape = (128 * CONFIG.N_ARTIFACTS,)
 head_model = create_head(head_input_shape, dropout=CONFIG.USE_CROPOUT)
-# head_model.summary()
 
 # Implement artifact flow through the same model
 model_input = layers.Input(

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/train.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/train.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 import os
 import random
-from typing import List
 
 import glob2 as glob
 import tensorflow as tf
@@ -11,7 +10,7 @@ from tensorflow.keras import callbacks, layers, models
 
 from config import CONFIG, DATASET_MODE_DOWNLOAD, DATASET_MODE_MOUNT
 from constants import DATA_DIR_ONLINE_RUN, REPO_DIR
-from model import create_base_cnn, create_head, load_base_cgm_model
+from model import create_head, get_base_model
 from preprocessing import create_samples, tf_load_pickle, tf_augment_sample
 from utils import download_dataset, get_dataset_path
 
@@ -137,28 +136,8 @@ del dataset_norm
 # Note: Now the datasets are prepared.
 
 
-def download_pretrained_model(output_model_fpath):
-    print(f"Downloading pretrained model from {CONFIG.PRETRAINED_RUN}")
-    previous_experiment = Experiment(workspace=workspace, name=CONFIG.PRETRAINED_EXPERIMENT)
-    previous_run = Run(previous_experiment, CONFIG.PRETRAINED_RUN)
-    previous_run.download_file("outputs/best_model.h5", output_model_fpath)
-
-
-def get_base_model():
-    if CONFIG.PRETRAINED_RUN:
-        model_fpath = DATA_DIR / "pretrained/" / CONFIG.PRETRAINED_RUN / "best_model.h5"
-        if not os.path.exists(model_fpath):
-            download_pretrained_model(model_fpath)
-        print(f"Loading pretrained model from {model_fpath}")
-        base_model = load_base_cgm_model(model_fpath, should_freeze=CONFIG.SHOULD_FREEZE_BASE)
-    else:
-        input_shape = (CONFIG.IMAGE_TARGET_HEIGHT, CONFIG.IMAGE_TARGET_WIDTH, 1)
-        base_model = create_base_cnn(input_shape, dropout=CONFIG.USE_DROPOUT)  # output_shape: (128,)
-    return base_model
-
-
 # Create the base model
-base_model = get_base_model()
+base_model = get_base_model(DATA_DIR)
 base_model.summary()
 assert base_model.output_shape == (None, 128)
 

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/train.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/train.py
@@ -12,7 +12,7 @@ from tensorflow.keras import callbacks, layers, models
 from config import CONFIG, DATASET_MODE_DOWNLOAD, DATASET_MODE_MOUNT
 from constants import DATA_DIR_ONLINE_RUN, REPO_DIR
 from model import create_base_cnn, create_head, load_base_cgm_model
-from preprocessing import create_multiartifact_paths, tf_load_pickle, tf_augment_sample
+from preprocessing import create_samples, tf_load_pickle, tf_augment_sample
 from utils import download_dataset, get_dataset_path
 
 # Make experiment reproducible
@@ -89,17 +89,6 @@ print(len(qrcode_paths_training))
 print(len(qrcode_paths_validate))
 
 assert len(qrcode_paths_training) > 0 and len(qrcode_paths_validate) > 0
-
-
-def create_samples(qrcode_paths: List[str]) -> List[List[str]]:
-    samples = []
-    for qrcode_path in sorted(qrcode_paths):
-        for code in CONFIG.CODES_FOR_POSE_AND_SCANSTEP:
-            p = os.path.join(qrcode_path, code)
-            new_samples = create_multiartifact_paths(p, CONFIG.N_ARTIFACTS)
-            samples.extend(new_samples)
-    return samples
-
 
 paths_training = create_samples(qrcode_paths_training)
 print(f"Samples for training: {len(paths_training)}")

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/train.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/train.py
@@ -71,8 +71,6 @@ split_index = int(len(qrcode_paths) * 0.8)
 qrcode_paths_training = qrcode_paths[:split_index]
 
 qrcode_paths_validate = qrcode_paths[split_index:]
-qrcode_paths_activation = random.choice(qrcode_paths_validate)
-qrcode_paths_activation = [qrcode_paths_activation]
 
 del qrcode_paths
 
@@ -81,8 +79,6 @@ print("Paths for training:")
 print("\t" + "\n\t".join(qrcode_paths_training))
 print("Paths for validation:")
 print("\t" + "\n\t".join(qrcode_paths_validate))
-print("Paths for activation:")
-print("\t" + "\n\t".join(qrcode_paths_activation))
 
 print(len(qrcode_paths_training))
 print(len(qrcode_paths_validate))
@@ -94,9 +90,6 @@ print(f"Samples for training: {len(paths_training)}")
 
 paths_validate = create_samples(qrcode_paths_validate)
 print(f"Samples for validate: {len(paths_validate)}")
-
-paths_activate = create_samples(qrcode_paths_activation)
-print(f"Samples for activate: {len(paths_activate)}")
 
 # Create dataset for training.
 paths = paths_training  # list
@@ -123,15 +116,6 @@ dataset_norm = dataset_norm.cache()
 dataset_norm = dataset_norm.prefetch(tf.data.experimental.AUTOTUNE)
 dataset_validation = dataset_norm
 del dataset_norm
-
-# Create dataset for activation
-# paths = paths_activate
-# dataset = tf.data.Dataset.from_tensor_slices(paths)
-# dataset_norm = dataset.map(lambda path: tf_load_pickle(path), tf.data.experimental.AUTOTUNE)
-# dataset_norm = dataset_norm.cache()
-# dataset_norm = dataset_norm.prefetch(tf.data.experimental.AUTOTUNE)
-# dataset_activation = dataset_norm
-# del dataset_norm
 
 # Note: Now the datasets are prepared.
 

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/utils.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/utils.py
@@ -2,7 +2,9 @@ import datetime
 import os
 from pathlib import Path
 
+from azureml.core.run import Run
 from azureml.core.workspace import Workspace
+from tensorflow.keras import callbacks
 
 
 def download_dataset(workspace: Workspace, dataset_name: str, dataset_path: str):
@@ -17,3 +19,30 @@ def download_dataset(workspace: Workspace, dataset_name: str, dataset_path: str)
 
 def get_dataset_path(data_dir: Path, dataset_name: str):
     return str(data_dir / dataset_name)
+
+
+class AzureLogCallback(callbacks.Callback):
+    """Pushes metrics and losses into the run on AzureML"""
+    def __init__(self, run: Run):
+        super().__init__()
+        self.run = run
+
+    def on_epoch_end(self, epoch, logs=None):
+        if logs is not None:
+            for key, value in logs.items():
+                self.run.log(key, value)
+
+
+def create_tensorboard_callback() -> callbacks.TensorBoard:
+    return callbacks.TensorBoard(
+        log_dir="logs",
+        histogram_freq=0,
+        write_graph=True,
+        write_grads=False,
+        write_images=True,
+        embeddings_freq=0,
+        embeddings_layer_names=None,
+        embeddings_metadata=None,
+        embeddings_data=None,
+        update_freq="epoch"
+    )


### PR DESCRIPTION
**Motivation**: `train.py` was quite long. 

**Solution:** In order to alleviate this problem, code is put into other modules.

**Changes:**
* Move create_samples() function into preprocessing.py
* Move get_base_model() and download_pretrained_model() into model.py
* Put callbacks into utils() function
* Remove code for activation because unused

**Check if this still works:**
- I ran the pipeline locally
- I made a run on a cluster, see [this run](https://ml.azure.com/experiments/id/ae599009-2154-4928-b46e-676866e12c61/runs/q3-depthmapmultiartifactlatefusion-plaincnn-height-95k-debug_1603878685_5b8e9d6e?wsid=/subscriptions/9b82ecea-6780-4b85-8acf-d27d79028f07/resourceGroups/cgm-ml-prod/providers/Microsoft.MachineLearningServices/workspaces/cgm-azureml-prod&tid=006dabd7-456d-465b-a87f-f7d557e319c8)
