### PR TITLE
Depthmap toolkit measure click function fixed

### DIFF
--- a/src/common/depthmap_toolkit/depthmap.py
+++ b/src/common/depthmap_toolkit/depthmap.py
@@ -22,7 +22,7 @@ def onclick(event):
     width = utils.getWidth()
     height = utils.getHeight()
     if event.xdata is not None and event.ydata is not None:
-        x = width - int(event.ydata) - 1
+        x = int(event.ydata)
         y = height - int(event.xdata) - 1
         if x > 1 and y > 1 and x < width - 2 and y < height - 2:
             depth = utils.parseDepth(x, y)


### PR DESCRIPTION
# Description

Depthmap toolkit has a feature to write coordinates and distances between the clicks in depthmap. However due to swapped axis it did not work correctly.

[bug report](https://dev.azure.com/cgmorg/ChildGrowthMonitor/_workitems/edit/335)

# How Has This Been Tested?

* checking if undefined areas returned correct values
* measuring objects with known dimensions
