### PR TITLE
Set eval trigger to none

### DIFF
--- a/src/common/eval/QA/test-pipeline.yml
+++ b/src/common/eval/QA/test-pipeline.yml
@@ -1,8 +1,4 @@
-  trigger:
-    batch: true
-    branches:
-      include:
-      - test-pipeline
+  trigger: none
 
   jobs:
   - job: EvaluationJob


### PR DESCRIPTION
Eval pipeline is getting triggered every PR. Set it to none.
We need to run the evaluation from azure dev once we commit the changes in qa_config.py