### PR TITLE
Modify the depthmap toolkits to return depthmaps as array and write them into .depth file into tow diffrent function

### DIFF
--- a/src/common/depthmap_toolkit/convertpcd2depth.py
+++ b/src/common/depthmap_toolkit/convertpcd2depth.py
@@ -3,7 +3,6 @@ import shutil
 import sys
 from os import walk
 from shutil import copyfile
-
 import pcd2depth
 
 if __name__ == "__main__":
@@ -11,7 +10,6 @@ if __name__ == "__main__":
         print('You did not enter pcd_dir folder')
         print('E.g.: python convertpcd2depth.py pcd_dir')
         sys.exit(1)
-
     pcd_dir = sys.argv[1]
     pcd = []
     for (dirpath, dirnames, filenames) in walk(pcd_dir):
@@ -25,6 +23,6 @@ if __name__ == "__main__":
     os.mkdir('output/depth')
     copyfile(pcd_dir + '/../camera_calibration.txt', 'output/camera_calibration.txt')
     for i in range(len(pcd)):
-       depthmap = pcd2depth.process('camera_calibration.txt', pcd_dir + '/' + pcd[i])
-       pcd2depth.write_depthmap('output/depth/' + pcd[i] + '.depth', depthmap)
+        depthmap = pcd2depth.process('camera_calibration.txt', pcd_dir + '/' + pcd[i])
+        pcd2depth.write_depthmap('output/depth/' + pcd[i] + '.depth', depthmap)
     print('Data exported into folder output')

--- a/src/common/depthmap_toolkit/convertpcd2depth.py
+++ b/src/common/depthmap_toolkit/convertpcd2depth.py
@@ -25,5 +25,6 @@ if __name__ == "__main__":
     os.mkdir('output/depth')
     copyfile(pcd_dir + '/../camera_calibration.txt', 'output/camera_calibration.txt')
     for i in range(len(pcd)):
-        pcd2depth.process('camera_calibration.txt', pcd_dir + '/' + pcd[i], 'output/depth/' + pcd[i] + '.depth')
+       depthmap = pcd2depth.process('camera_calibration.txt', pcd_dir + '/' + pcd[i])
+       pcd2depth.write_depthmap('output/depth/' + pcd[i] + '.depth', depthmap)
     print('Data exported into folder output')

--- a/src/common/depthmap_toolkit/pcd2depth.py
+++ b/src/common/depthmap_toolkit/pcd2depth.py
@@ -1,12 +1,8 @@
 import zipfile
-
 import numpy as np
-
 import utils
 
-
 ENCODING = 'charmap'
-
 utils.setWidth(int(240 * 0.75))
 utils.setHeight(int(180 * 0.75))
 width = utils.getWidth()
@@ -25,7 +21,6 @@ def process(calibration_fname: str, pcd_fpath: str):
             output[x][y][0] = p[3]
             output[x][y][2] = p[2]
     return output
-
 def write_depthmap(output_depth_fpath: str, depthmap):
     # Write depthmap
     with open('data', 'wb') as f:
@@ -45,8 +40,6 @@ def write_depthmap(output_depth_fpath: str, depthmap):
     with zipfile.ZipFile(output_depth_fpath, "w", zipfile.ZIP_DEFLATED) as f:
         f.write('data', 'data')
         f.close()
-
-
     # Visualsiation for debug
     #print str(width) + "x" + str(height)
     #plt.imshow(output)

--- a/src/common/depthmap_toolkit/pcd2depth.py
+++ b/src/common/depthmap_toolkit/pcd2depth.py
@@ -7,17 +7,15 @@ import utils
 
 ENCODING = 'charmap'
 
+utils.setWidth(int(240 * 0.75))
+utils.setHeight(int(180 * 0.75))
+width = utils.getWidth()
+height = utils.getHeight()
 
-def process(calibration_fname: str, pcd_fpath: str, output_depth_fpath: str):
-    # Read pcd and calibration files
+def process(calibration_fname: str, pcd_fpath: str):
+    # Convert to depthmap
     calibration = utils.parseCalibration(calibration_fname)
     points = utils.parsePCD(pcd_fpath)
-    utils.setWidth(int(240 * 0.75))
-    utils.setHeight(int(180 * 0.75))
-
-    # Convert to depthmap
-    width = utils.getWidth()
-    height = utils.getHeight()
     output = np.zeros((width, height, 3))
     for p in points:
         v = utils.convert3Dto2D(calibration[1], p[0], p[1], p[2])
@@ -26,29 +24,28 @@ def process(calibration_fname: str, pcd_fpath: str, output_depth_fpath: str):
         if x >= 0 and y >= 0 and x < width and y < height:
             output[x][y][0] = p[3]
             output[x][y][2] = p[2]
+    return output
 
+def write_depthmap(output_depth_fpath: str, depthmap):
     # Write depthmap
     with open('data', 'wb') as f:
         header_str = str(width) + 'x' + str(height) + '_0.001_255\n'
-
         f.write(header_str.encode(ENCODING))
         for y in range(height):
             for x in range(width):
-                depth = int(output[x][y][2] * 1000)
-                confidence = int(output[x][y][0] * 255)
-
+                depth = int(depthmap[x][y][2] * 1000)
+                confidence = int(depthmap[x][y][0] * 255)
                 depth_byte = chr(int(depth / 256)).encode(ENCODING)
                 depth_byte2 = chr(depth % 256).encode(ENCODING)
                 confidence_byte = chr(confidence).encode(ENCODING)
-
                 f.write(depth_byte)
                 f.write(depth_byte2)
                 f.write(confidence_byte)
-
     # Zip data
     with zipfile.ZipFile(output_depth_fpath, "w", zipfile.ZIP_DEFLATED) as f:
         f.write('data', 'data')
         f.close()
+
 
     # Visualsiation for debug
     #print str(width) + "x" + str(height)

--- a/src/common/depthmap_toolkit/toolkit.py
+++ b/src/common/depthmap_toolkit/toolkit.py
@@ -28,10 +28,10 @@ def convertAllPCDs(event):
     os.mkdir('output/depth')
     copyfile(input_dir + '/../camera_calibration.txt', 'output/camera_calibration.txt')
     for i in range(len(pcd)):
-        pcd2depth.process(
+        depthmap = pcd2depth.process(
             input_dir + '/../camera_calibration.txt',
-            input_dir + '/' + pcd[i],
-            'output/depth/' + pcd[i] + '.depth')
+            input_dir + '/' + pcd[i])
+        pcd2depth.write_depthmap('output/depth/' + pcd[i] + '.depth',depthmap)
     print('Data exported into folder output')
 
 

--- a/src/common/depthmap_toolkit/toolkit.py
+++ b/src/common/depthmap_toolkit/toolkit.py
@@ -28,10 +28,8 @@ def convertAllPCDs(event):
     os.mkdir('output/depth')
     copyfile(input_dir + '/../camera_calibration.txt', 'output/camera_calibration.txt')
     for i in range(len(pcd)):
-        depthmap = pcd2depth.process(
-            input_dir + '/../camera_calibration.txt',
-            input_dir + '/' + pcd[i])
-        pcd2depth.write_depthmap('output/depth/' + pcd[i] + '.depth',depthmap)
+        depthmap = pcd2depth.process(input_dir + '/../camera_calibration.txt', input_dir + '/' + pcd[i])
+        pcd2depth.write_depthmap('output/depth/' + pcd[i] + '.depth', depthmap)
     print('Data exported into folder output')
 
 


### PR DESCRIPTION
# Description

Modified the pcd2depth.process() function into two functions now. pcd2depth. prcoess() , it now returns the depthmap array and pcd2depthmap.write_depthmap() writes the depthmap into .depth file.

User story # (US link): none

# How Has This Been Tested?

After making changes, ran these file to check the proper functionality

- [x] python convertpcd2depth.py 
- [x] python toolkit.py


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests
- [ ] New and existing unit tests pass locally with my changes
- [x] My Code is review by 1 People
