### PR TITLE
Update pytest pip dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ ipywidgets==7.2.1
 face_recognition==1.3.0
 imgaug==0.4.0
 flake8==3.8.4
-pytest==5.4.2
-pytest-cov==2.10.0
+pytest==6.1.2
+pytest-cov==2.10.1
 pytest-azurepipelines==0.8.0
 xmltodict==0.12.0


### PR DESCRIPTION
This PR will avoid this warning when running `pytest`: 

```
=============================================================================================================================== warnings summary ===============================================================================================================================
/Users/markus/.virtualenvs/env_p_3/lib/python3.7/site-packages/_pytest/junitxml.py:417
  /Users/markus/.virtualenvs/env_p_3/lib/python3.7/site-packages/_pytest/junitxml.py:417: PytestDeprecationWarning: The 'junit_family' default value will change to 'xunit2' in pytest 6.0.
  Add 'junit_family=xunit1' to your pytest.ini file to keep the current format in future versions of pytest and silence this warning.
    _issue_warning_captured(deprecated.JUNIT_XML_DEFAULT_FAMILY, config.hook, 2)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```