### PR TITLE
Disable qa pipeline (because it is broken)

### DIFF
--- a/src/common/evaluation/QA/test-pipeline.yml
+++ b/src/common/evaluation/QA/test-pipeline.yml
@@ -1,7 +1,6 @@
 trigger:
   branches:
     include:
-    - master
     - releases/*
 
 pr: none


### PR DESCRIPTION
**Problem:** 
- The master build of cgm-ml seems to be broken, see https://github.com/Welthungerhilfe/cgm-ml/runs/1441345384
- we have 3 pipelines in this repo
    - `cmg-ml`: `azure-pipelines.yml` flake8 and pytest
    - `cmg-ml (1)`: `src/common/evaluation/QA/test-pipeline.yml` evaluate models
    - `cmg-ml (2)`: `src/common/zscore/azure-pipelines.yml` release z-score
- pushing to master triggers all pipelines, but `cmg-ml (1)` is broken

**Solution**: disable `cmg-ml (1)`

There is an option to disable a pipeline in azure devops: https://dev.azure.com/cgmorg/ChildGrowthMonitor/_build?definitionId=3