### PR TITLE
Introduce rgbd debug flag

### DIFF
--- a/src/common/rgbd_toolkit/rgbd.py
+++ b/src/common/rgbd_toolkit/rgbd.py
@@ -170,6 +170,9 @@ if __name__ == "__main__":
                         type=int,
                         default=None,
                         help="no. of cpu workers you want to process with")
+    parser.add_argument("--debug",
+                        action='store_true',
+                        help="Flag to enable debug mode")
     parser.add_argument(
         "--pickled",
         action='store_true',
@@ -227,10 +230,16 @@ if __name__ == "__main__":
         paths = get_files(norm_rgb_time, rgb_path, norm_pcd_time, pcd_path)
 
         #processing every pcd file with its nearest rgb using multiprocessing workers
-        with concurrent.futures.ProcessPoolExecutor(
-                max_workers=args.num_workers) as executor:
-            res = list(tqdm(executor.map(process_pcd, paths),
-                            total=len(paths)))
+        if args.debug:
+            print("Debug")
+            for path in paths:
+                process_pcd(path)
+        else:
+            print("Multiprocessing")
+            with concurrent.futures.ProcessPoolExecutor(
+                    max_workers=args.num_workers) as executor:
+                res = list(tqdm(executor.map(process_pcd, paths),
+                                total=len(paths)))
 
     end = datetime.datetime.now()
     diff = end - start


### PR DESCRIPTION
**Motivation:** The RGBD code is still quite unstable, so it would be good to be able to disable multiprocessing. 

**Solution:** a debug flag helps to disable multiprocessing

**How to use this**
```bash
python rgbd.py --input input_dir/ --output output_dir/ --debug
```