### PR TITLE
Fix eval/ vs evaluation/ dir bug

### DIFF
--- a/src/common/evaluation/QA/eval-depthmap-height/src/qa_config.py
+++ b/src/common/evaluation/QA/eval-depthmap-height/src/qa_config.py
@@ -27,7 +27,6 @@ EVAL_CONFIG = dotdict(dict(
 
     #Used for Debug the QA pipeline
     DEBUG_RUN=False,
-    #DEBUG_RUN = True,
 
     #Will run eval on specified # of scan instead of full dataset
     DEBUG_NUMBER_OF_SCAN=50,

--- a/src/common/evaluation/QA/test-pipeline.yml
+++ b/src/common/evaluation/QA/test-pipeline.yml
@@ -18,7 +18,7 @@ jobs:
     displayName: 'QA Pipeline for cgm-ml-service'
 
   - bash: |
-      cd src/common/eval/QA
+      cd src/common/evaluation/QA
       source /usr/share/miniconda/etc/profile.d/conda.sh
       conda env create -f environment.yml
       conda activate CGM_QA_Pipeline
@@ -32,14 +32,14 @@ jobs:
     displayName: 'Azure Login'
 
   - bash: |
-      cd src/common/eval/QA
+      cd src/common/evaluation/QA
       source /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CGM_QA_Pipeline
       python auth.py -sid $(subscriptionid) -rg $(RESOURCE_GROUP) -wn $(WORKSPACE_NAME)
     displayName: 'Saving Workspace Config'
 
   - bash: |
-      cd src/common/eval/QA/eval-depthmap-height
+      cd src/common/evaluation/QA/eval-depthmap-height
       source /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CGM_QA_Pipeline
       echo Executing eval_notebook.ipynb
@@ -49,7 +49,7 @@ jobs:
     displayName: 'Depthmap Height Model Evaluation'
 
   - bash: |
-      cd src/common/eval/QA/eval-standardisation-test
+      cd src/common/evaluation/QA/eval-standardisation-test
       source /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CGM_QA_Pipeline
       echo Executing eval_notebook.ipynb
@@ -62,10 +62,10 @@ jobs:
     inputs:
       SourceFolder: '$(Build.SourcesDirectory)'
       Contents: |
-        src/common/eval/QA/eval-depthmap-height/depthmap-height_output.html
-        src/common/eval/QA/eval-depthmap-height/*.csv
-        src/common/eval/QA/eval-standardisation-test/standardisation-test_output.html
-        src/common/eval/QA/eval-standardisation-test/*.csv
+        src/common/evaluation/QA/eval-depthmap-height/depthmap-height_output.html
+        src/common/evaluation/QA/eval-depthmap-height/*.csv
+        src/common/evaluation/QA/eval-standardisation-test/standardisation-test_output.html
+        src/common/evaluation/QA/eval-standardisation-test/*.csv
       TargetFolder: '$(Build.ArtifactStagingDirectory)'
     displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)'
 

--- a/src/common/evaluation/QA/test-pipeline.yml
+++ b/src/common/evaluation/QA/test-pipeline.yml
@@ -3,8 +3,6 @@ trigger:
     include:
     - releases/*
 
-pr: none
-
 jobs:
 - job: EvaluationJob
   timeoutInMinutes: 300

--- a/src/common/evaluation/QA/test-pipeline.yml
+++ b/src/common/evaluation/QA/test-pipeline.yml
@@ -3,6 +3,8 @@ trigger:
     include:
     - releases/*
 
+pr: none
+
 jobs:
 - job: EvaluationJob
   timeoutInMinutes: 300


### PR DESCRIPTION
Bug: model evaluation pipeline was broken.

This PR fixes this. 

How did I check this works:
- I added a commit that enables the pipeline
- I saw that the pipeline ran (see github Commits tab above in this PR)
- I disabled the pipeline so it doesn't always run for all future PR