### PR TITLE
Remove importlib2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ glob2==0.7
 open3d==0.8.0.0
 opencv-python==4.4.0.46
 matplotlib==2.2.2
-importlib2==3.5.0.2
 psycopg2==2.7.5
 tqdm==4.31.1
 pandas==0.23.4


### PR DESCRIPTION
**Motivation:** importlib2 is a backport, so should not be needed for Python3