### PR TITLE
Speed-up of model eval

### DIFF
--- a/src/common/evaluation/QA/environment.yml
+++ b/src/common/evaluation/QA/environment.yml
@@ -2,12 +2,12 @@ name: CGM_QA_Pipeline
 channels:
   - conda-forge
 dependencies:
-  - python=3.6
+  - python=3.7
   - nb_conda_kernels==2.2.1
   - scikit-image
   - pip:
     - azure-cli==2.0.69
-    - azureml-sdk[notebooks,automl]==1.13.0
+    - azureml-sdk[notebooks,automl]==1.18.0
     - papermill==1.0.1
     - nbconvert==5.6.0
     - matplotlib==3.2.1

--- a/src/common/evaluation/QA/eval-depthmap-height/eval_main.py
+++ b/src/common/evaluation/QA/eval-depthmap-height/eval_main.py
@@ -92,7 +92,7 @@ if __name__ == "__main__":
         compute_target=compute_target,
         entry_script="evaluate.py",
         use_gpu=True,
-        framework_version="2.2",
+        framework_version="2.3",
         inputs=[dataset.as_named_input("dataset").as_mount()],
         pip_packages=pip_packages,
         script_params=script_params

--- a/src/common/evaluation/QA/eval-depthmap-height/eval_main.py
+++ b/src/common/evaluation/QA/eval-depthmap-height/eval_main.py
@@ -91,7 +91,7 @@ if __name__ == "__main__":
         source_directory=temp_path,
         compute_target=compute_target,
         entry_script="evaluate.py",
-        use_gpu=False,
+        use_gpu=True,
         framework_version="2.3",
         inputs=[dataset.as_named_input("dataset").as_mount()],
         pip_packages=pip_packages,

--- a/src/common/evaluation/QA/eval-depthmap-height/eval_main.py
+++ b/src/common/evaluation/QA/eval-depthmap-height/eval_main.py
@@ -91,7 +91,7 @@ if __name__ == "__main__":
         source_directory=temp_path,
         compute_target=compute_target,
         entry_script="evaluate.py",
-        use_gpu=True,
+        use_gpu=False,
         framework_version="2.3",
         inputs=[dataset.as_named_input("dataset").as_mount()],
         pip_packages=pip_packages,

--- a/src/common/evaluation/QA/eval-depthmap-height/src/constants.py
+++ b/src/common/evaluation/QA/eval-depthmap-height/src/constants.py
@@ -1,3 +1,4 @@
 from pathlib import Path
 
 REPO_DIR = Path(__file__).parents[6].absolute()
+DATA_DIR_ONLINE_RUN = Path("/tmp/data/")

--- a/src/common/evaluation/QA/eval-depthmap-height/src/evaluate.py
+++ b/src/common/evaluation/QA/eval-depthmap-height/src/evaluate.py
@@ -1,22 +1,21 @@
 import argparse
-import datetime
 from importlib import import_module
-from pathlib import Path
 import os
 import random
 import pickle
-import numpy as np
-import pandas as pd
 import glob2 as glob
 import time
+
+import numpy as np
+import pandas as pd
 import tensorflow as tf
 from tensorflow.keras.models import load_model
-
 from azureml.core import Experiment, Workspace
 from azureml.core.run import Run
 
 import utils
-from constants import REPO_DIR
+from utils import download_dataset, get_dataset_path
+from constants import REPO_DIR, DATA_DIR_ONLINE_RUN
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--qa_config_module", default="qa_config_height", help="Configuration file")
@@ -68,23 +67,6 @@ def get_prediction(MODEL_PATH, dataset_evaluation):
 
     prediction_list = np.squeeze(predictions)
     return prediction_list
-
-
-def download_dataset(workspace: Workspace, dataset_name: str, dataset_path: str):
-    print("Accessing dataset...")
-    if os.path.exists(dataset_path):
-        return
-    dataset = workspace.datasets[dataset_name]
-    print("Downloading dataset.. Current date and time: ", datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
-    dataset.download(target_path=dataset_path, overwrite=False)
-    print("Finished downloading, Current date and time: ", datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
-
-
-def get_dataset_path(data_dir: Path, dataset_name: str):
-    return str(data_dir / dataset_name)
-
-
-DATA_DIR_ONLINE_RUN = Path("/tmp/data/")
 
 
 if __name__ == "__main__":

--- a/src/common/evaluation/QA/eval-depthmap-height/src/evaluate.py
+++ b/src/common/evaluation/QA/eval-depthmap-height/src/evaluate.py
@@ -6,6 +6,7 @@ import pickle
 import numpy as np
 import pandas as pd
 import glob2 as glob
+import time
 import tensorflow as tf
 from tensorflow.keras.models import load_model
 
@@ -54,7 +55,15 @@ def get_prediction(MODEL_PATH, dataset_evaluation):
         need to performed
     '''
     model = load_model(MODEL_PATH, compile=False)
-    predictions = model.predict(dataset_evaluation.batch(DATA_CONFIG.BATCH_SIZE))
+
+    aaa = dataset_evaluation.batch(DATA_CONFIG.BATCH_SIZE)
+
+    print("starting predicting")
+    start = time.time()
+    predictions = model.predict(aaa, batch_size=DATA_CONFIG.BATCH_SIZE)  # Takes long
+    end = time.time()
+    print("Total time for prediction experiment: {} sec".format(end - start))
+
     prediction_list = np.squeeze(predictions)
     return prediction_list
 
@@ -118,14 +127,19 @@ if __name__ == "__main__":
 
     print("Using {} artifact files for evaluation.".format(len(paths_evaluation)))
 
-    # Create dataset for training.
     paths = paths_evaluation
     dataset = tf.data.Dataset.from_tensor_slices(paths)
+    print("1.")
     dataset_norm = dataset.map(lambda path: tf_load_pickle(path, DATA_CONFIG.NORMALIZATION_VALUE))
+    print("2.")
     dataset_norm = dataset_norm.cache()
+    print("3.")
     dataset_norm = dataset_norm.prefetch(tf.data.experimental.AUTOTUNE)
+    print("4.")
     dataset_evaluation = dataset_norm
+    print("5.")
     del dataset_norm
+    print("Created dataset for training.")
 
     # Get the prediction
     if MODEL_CONFIG.NAME.endswith(".h5"):

--- a/src/common/evaluation/QA/eval-depthmap-height/src/evaluate.py
+++ b/src/common/evaluation/QA/eval-depthmap-height/src/evaluate.py
@@ -64,6 +64,9 @@ def get_prediction(MODEL_PATH, dataset_evaluation):
     end = time.time()
     print("Total time for prediction experiment: {} sec".format(end - start))
 
+
+    print("Num GPUs Available: ", len(tf.config.experimental.list_physical_devices('GPU')))
+
     prediction_list = np.squeeze(predictions)
     return prediction_list
 

--- a/src/common/evaluation/QA/eval-depthmap-height/src/evaluate.py
+++ b/src/common/evaluation/QA/eval-depthmap-height/src/evaluate.py
@@ -1,5 +1,7 @@
 import argparse
+import datetime
 from importlib import import_module
+from pathlib import Path
 import os
 import random
 import pickle
@@ -68,6 +70,23 @@ def get_prediction(MODEL_PATH, dataset_evaluation):
     return prediction_list
 
 
+def download_dataset(workspace: Workspace, dataset_name: str, dataset_path: str):
+    print("Accessing dataset...")
+    if os.path.exists(dataset_path):
+        return
+    dataset = workspace.datasets[dataset_name]
+    print("Downloading dataset.. Current date and time: ", datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
+    dataset.download(target_path=dataset_path, overwrite=False)
+    print("Finished downloading, Current date and time: ", datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
+
+
+def get_dataset_path(data_dir: Path, dataset_name: str):
+    return str(data_dir / dataset_name)
+
+
+DATA_DIR_ONLINE_RUN = Path("/tmp/data/")
+
+
 if __name__ == "__main__":
 
     # Make experiment reproducible
@@ -100,7 +119,12 @@ if __name__ == "__main__":
         print("Running in online mode...")
         experiment = run.experiment
         workspace = experiment.workspace
-        dataset_path = run.input_datasets["dataset"]
+
+        dataset_name = DATA_CONFIG.NAME
+
+        # Download
+        dataset_path = get_dataset_path(DATA_DIR_ONLINE_RUN, dataset_name)
+        download_dataset(workspace, dataset_name, dataset_path)
 
     # Get the QR-code paths.
     dataset_path = os.path.join(dataset_path, "scans")

--- a/src/common/evaluation/QA/eval-depthmap-height/src/evaluate.py
+++ b/src/common/evaluation/QA/eval-depthmap-height/src/evaluate.py
@@ -66,6 +66,8 @@ def get_prediction(MODEL_PATH, dataset_evaluation):
 
 
     print("Num GPUs Available: ", len(tf.config.experimental.list_physical_devices('GPU')))
+    from tensorflow.python.client import device_lib
+    print(device_lib.list_local_devices())
 
     prediction_list = np.squeeze(predictions)
     return prediction_list

--- a/src/common/evaluation/QA/eval-depthmap-height/src/evaluate.py
+++ b/src/common/evaluation/QA/eval-depthmap-height/src/evaluate.py
@@ -56,18 +56,13 @@ def get_prediction(MODEL_PATH, dataset_evaluation):
     '''
     model = load_model(MODEL_PATH, compile=False)
 
-    aaa = dataset_evaluation.batch(DATA_CONFIG.BATCH_SIZE)
+    dataset = dataset_evaluation.batch(DATA_CONFIG.BATCH_SIZE)
 
     print("starting predicting")
     start = time.time()
-    predictions = model.predict(aaa, batch_size=DATA_CONFIG.BATCH_SIZE)  # Takes long
+    predictions = model.predict(dataset, batch_size=DATA_CONFIG.BATCH_SIZE)
     end = time.time()
     print("Total time for prediction experiment: {} sec".format(end - start))
-
-
-    print("Num GPUs Available: ", len(tf.config.experimental.list_physical_devices('GPU')))
-    from tensorflow.python.client import device_lib
-    print(device_lib.list_local_devices())
 
     prediction_list = np.squeeze(predictions)
     return prediction_list
@@ -132,17 +127,13 @@ if __name__ == "__main__":
 
     print("Using {} artifact files for evaluation.".format(len(paths_evaluation)))
 
+    print("Creating dataset for training.")
     paths = paths_evaluation
     dataset = tf.data.Dataset.from_tensor_slices(paths)
-    print("1.")
     dataset_norm = dataset.map(lambda path: tf_load_pickle(path, DATA_CONFIG.NORMALIZATION_VALUE))
-    print("2.")
     dataset_norm = dataset_norm.cache()
-    print("3.")
     dataset_norm = dataset_norm.prefetch(tf.data.experimental.AUTOTUNE)
-    print("4.")
     dataset_evaluation = dataset_norm
-    print("5.")
     del dataset_norm
     print("Created dataset for training.")
 

--- a/src/common/evaluation/QA/eval-depthmap-height/src/qa_config_height.py
+++ b/src/common/evaluation/QA/eval-depthmap-height/src/qa_config_height.py
@@ -26,7 +26,7 @@ EVAL_CONFIG = dotdict(dict(
     CLUSTER_NAME="gpu-cluster",
 
     #Used for Debug the QA pipeline
-    DEBUG_RUN=True,
+    DEBUG_RUN=False,
 
     #Will run eval on specified # of scan instead of full dataset
     DEBUG_NUMBER_OF_SCAN=50,
@@ -37,7 +37,7 @@ EVAL_CONFIG = dotdict(dict(
 #Details of Evaluation Dataset
 DATA_CONFIG = dotdict(dict(
     #Name of evaluation dataset
-    NAME='anon-depthmap-mini',
+    NAME='anon-depthmap-testset',
 
     IMAGE_TARGET_HEIGHT=240,
     IMAGE_TARGET_WIDTH=180,

--- a/src/common/evaluation/QA/eval-depthmap-height/src/qa_config_height.py
+++ b/src/common/evaluation/QA/eval-depthmap-height/src/qa_config_height.py
@@ -43,7 +43,7 @@ DATA_CONFIG = dotdict(dict(
     IMAGE_TARGET_WIDTH=180,
 
     #Batch size for evaluation
-    BATCH_SIZE=512,
+    BATCH_SIZE=1024,
     NORMALIZATION_VALUE=7.5,
 
     # Parameters for dataset generation.

--- a/src/common/evaluation/QA/eval-depthmap-height/src/qa_config_height.py
+++ b/src/common/evaluation/QA/eval-depthmap-height/src/qa_config_height.py
@@ -43,7 +43,7 @@ DATA_CONFIG = dotdict(dict(
     IMAGE_TARGET_WIDTH=180,
 
     #Batch size for evaluation
-    BATCH_SIZE=1024,
+    BATCH_SIZE=512,
     NORMALIZATION_VALUE=7.5,
 
     # Parameters for dataset generation.

--- a/src/common/evaluation/QA/eval-depthmap-height/src/qa_config_height.py
+++ b/src/common/evaluation/QA/eval-depthmap-height/src/qa_config_height.py
@@ -26,7 +26,7 @@ EVAL_CONFIG = dotdict(dict(
     CLUSTER_NAME="gpu-cluster",
 
     #Used for Debug the QA pipeline
-    DEBUG_RUN=False,
+    DEBUG_RUN=True,
 
     #Will run eval on specified # of scan instead of full dataset
     DEBUG_NUMBER_OF_SCAN=50,
@@ -43,7 +43,7 @@ DATA_CONFIG = dotdict(dict(
     IMAGE_TARGET_WIDTH=180,
 
     #Batch size for evaluation
-    BATCH_SIZE=256,
+    BATCH_SIZE=512,
     NORMALIZATION_VALUE=7.5,
 
     # Parameters for dataset generation.

--- a/src/common/evaluation/QA/eval-depthmap-height/src/qa_config_height.py
+++ b/src/common/evaluation/QA/eval-depthmap-height/src/qa_config_height.py
@@ -37,7 +37,7 @@ EVAL_CONFIG = dotdict(dict(
 #Details of Evaluation Dataset
 DATA_CONFIG = dotdict(dict(
     #Name of evaluation dataset
-    NAME='anon-depthmap-testset',
+    NAME='anon-depthmap-mini',
 
     IMAGE_TARGET_HEIGHT=240,
     IMAGE_TARGET_WIDTH=180,

--- a/src/common/evaluation/QA/eval-depthmap-height/src/utils.py
+++ b/src/common/evaluation/QA/eval-depthmap-height/src/utils.py
@@ -1,10 +1,26 @@
+import datetime
 import os
+from pathlib import Path
 import pickle
 
-from azureml.core import Experiment, Run
+from azureml.core import Experiment, Run, Workspace
 import glob2 as glob
 import numpy as np
 import pandas as pd
+
+
+def download_dataset(workspace: Workspace, dataset_name: str, dataset_path: str):
+    print("Accessing dataset...")
+    if os.path.exists(dataset_path):
+        return
+    dataset = workspace.datasets[dataset_name]
+    print("Downloading dataset.. Current date and time: ", datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
+    dataset.download(target_path=dataset_path, overwrite=False)
+    print("Finished downloading, Current date and time: ", datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
+
+
+def get_dataset_path(data_dir: Path, dataset_name: str):
+    return str(data_dir / dataset_name)
 
 
 def preprocess_depthmap(depthmap):

--- a/src/common/evaluation/QA/test-pipeline.yml
+++ b/src/common/evaluation/QA/test-pipeline.yml
@@ -3,8 +3,6 @@ trigger:
     include:
     - releases/*
 
-pr: none
-
 jobs:
 - job: EvaluationJob
   timeoutInMinutes: 300

--- a/src/common/evaluation/QA/test-pipeline.yml
+++ b/src/common/evaluation/QA/test-pipeline.yml
@@ -41,19 +41,8 @@ jobs:
       source /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CGM_QA_Pipeline
       python eval_main.py --qa_config_module qa_config_height
-      python eval_main.py --qa_config_module qa_config_weight
       ls -l
     displayName: 'Depthmap Height Model Evaluation'
-
-  - bash: |
-      set -euox pipefail
-      cd src/common/evaluation/QA/eval-standardisation-test
-      source /usr/share/miniconda/etc/profile.d/conda.sh
-      conda activate CGM_QA_Pipeline
-      papermill eval_notebook.ipynb standardisation-test_output.ipynb --log-output --no-progress-bar -k python3
-      jupyter nbconvert --to html standardisation-test_output.ipynb
-      ls -l
-    displayName: 'Standardisation Test Model Evaluation'
 
   - task: CopyFiles@2
     inputs:

--- a/src/common/evaluation/QA/test-pipeline.yml
+++ b/src/common/evaluation/QA/test-pipeline.yml
@@ -41,8 +41,19 @@ jobs:
       source /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CGM_QA_Pipeline
       python eval_main.py --qa_config_module qa_config_height
+      python eval_main.py --qa_config_module qa_config_weight
       ls -l
     displayName: 'Depthmap Height Model Evaluation'
+
+  - bash: |
+      set -euox pipefail
+      cd src/common/evaluation/QA/eval-standardisation-test
+      source /usr/share/miniconda/etc/profile.d/conda.sh
+      conda activate CGM_QA_Pipeline
+      papermill eval_notebook.ipynb standardisation-test_output.ipynb --log-output --no-progress-bar -k python3
+      jupyter nbconvert --to html standardisation-test_output.ipynb
+      ls -l
+    displayName: 'Standardisation Test Model Evaluation'
 
   - task: CopyFiles@2
     inputs:


### PR DESCRIPTION
**Findings:** Mounting the data slows down prediction time because the data has to be fetched over the network. It is a lot faster to fully download the data before starting to predict.

**Changes:**
- Download instead of mounting (to speed up)
- Use batch size of 1024 instead of 256 (to speed up)
- remove caching since we use every sample only once in model evaluation (unlike in training)
- add some print statements to mention how fast the prediction
- Use TF2.3 and py3.7

**Details about speed measurements**

Before this PR: The run takes 32m 10.37s ([Run 204](https://ml.azure.com/experiments/id/4347c355-aa9d-4482-b7d9-2130b9aa7c44/runs/QA-pipeline_1606901417_9803b4cd?wsid=/subscriptions/9b82ecea-6780-4b85-8acf-d27d79028f07/resourceGroups/cgm-ml-prod/providers/Microsoft.MachineLearningServices/workspaces/cgm-azureml-prod&tid=006dabd7-456d-465b-a87f-f7d557e319c8),  [pipeline](https://dev.azure.com/cgmorg/ChildGrowthMonitor/_build/results?buildId=1658&view=logs&j=3d42b299-58dd-525f-2f90-47c9dbee9ebd&t=66a92730-1935-5d8a-99af-e052f481c0da))

We tried downloading data instead of mounting:
- Download data first: 8m 58.57s [Run 254](https://ml.azure.com/experiments/id/4347c355-aa9d-4482-b7d9-2130b9aa7c44/runs/QA-pipeline_1606990079_adfd3b4a?wsid=/subscriptions/9b82ecea-6780-4b85-8acf-d27d79028f07/resourceGroups/cgm-ml-prod/providers/Microsoft.MachineLearningServices/workspaces/cgm-azureml-prod&tid=006dabd7-456d-465b-a87f-f7d557e319c8), [pipeline](https://dev.azure.com/cgmorg/ChildGrowthMonitor/_build/results?buildId=1711&view=logs&j=3d42b299-58dd-525f-2f90-47c9dbee9ebd&t=66a92730-1935-5d8a-99af-e052f481c0da&l=14): Total time for prediction experiment: `206.96 sec = 3.45min`
-> This is a great improvement

Then we we tried to disable the GPU:
- Download data first, disable GPU: 18m 6.555s [Run 261](https://ml.azure.com/experiments/id/4347c355-aa9d-4482-b7d9-2130b9aa7c44/runs/QA-pipeline_1606992601_6e442285?wsid=/subscriptions/9b82ecea-6780-4b85-8acf-d27d79028f07/resourceGroups/cgm-ml-prod/providers/Microsoft.MachineLearningServices/workspaces/cgm-azureml-prod&tid=006dabd7-456d-465b-a87f-f7d557e319c8#outputsAndLogs): Total time for prediction experiment: `751.55 sec = 12.5min` 
-> This is actually worse so GPU seems to be enabled correctly (This is also what the logs show)

We tried to increase the batch size: 
- TF2.3, mini, predict from tf.data (debug=True, bs=512): 34s
- TF2.3, mini, predict from tf.data (debug=True, bs=1024): OOM

Before merging: Revert `pr: none`