### PR TITLE
Disable model eval pipeline for every PR

### DIFF
--- a/src/common/evaluation/QA/test-pipeline.yml
+++ b/src/common/evaluation/QA/test-pipeline.yml
@@ -3,6 +3,8 @@ trigger:
     include:
     - releases/*
 
+pr: none
+
 jobs:
 - job: EvaluationJob
   timeoutInMinutes: 300


### PR DESCRIPTION
This was an issue introduced by https://github.com/Welthungerhilfe/cgm-ml/pull/197/