### PR TITLE
Remove conda warning

### DIFF
--- a/src/common/evaluation/QA/environment.yml
+++ b/src/common/evaluation/QA/environment.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.7
+  - pip
   - nb_conda_kernels==2.2.1
   - scikit-image
   - pip:


### PR DESCRIPTION
Resolve warning: `Warning: you have pip-installed dependencies in your environment file, but you do not list pip itself as one of your conda dependencies by adding pip into conda dependencies`