### PR TITLE
Better confidence visualisation for depthmap toolkit

### DIFF
--- a/src/common/depthmap_toolkit/depthmap.py
+++ b/src/common/depthmap_toolkit/depthmap.py
@@ -88,6 +88,8 @@ def show_result():
                 #set output pixel
                 output[x][height - y - 1][:] = 1.0 - min(depth / 2.0, 1.0)  # depth data scaled to be visible
                 output[x][height + height - y - 1][:] = utils.parse_confidence(x, y)
+                if output[x][height + height - y - 1][0] == 0:
+                    output[x][height + height - y - 1][:] = 1
                 if vec[0] > 0 and vec[1] > 1 and vec[0] < width and vec[1] < height and has_rgb:
                     output[x][2 * height + height - y - 1][0] = im_array[int(vec[1])][int(vec[0])][0] / 255.0
                     output[x][2 * height + height - y - 1][1] = im_array[int(vec[1])][int(vec[0])][1] / 255.0


### PR DESCRIPTION
# Description

The visualisation of confidence was not nature for human eye (overbright==black). I fixed it by inverting overbright value.

The first picture overbright==black
The second picture overbright==white

![current master](https://user-images.githubusercontent.com/6472545/101459985-45173500-3939-11eb-8bbd-6afeca76f243.png)
![lvonasek-confidence-visualisation-better](https://user-images.githubusercontent.com/6472545/101460007-4b0d1600-3939-11eb-8658-34be6d74c68b.png)

Connected to bug ticket https://dev.azure.com/cgmorg/ChildGrowthMonitor/_workitems/edit/635/