### PR TITLE
Follow pep8 more closely

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,12 +1,6 @@
 [flake8]
 ignore =
-  # I100, I101: Import statements are in the wrong order. Too much a hazzle for now
-  I100, I101,
-  # W503 line break before binary operator. Deactivated because of incompatibility with black
-  W503,
-  # Personal taste
-  E701,
-  # Don't be too strict
+  W503,  # line break before binary operator. Deactivated because of incompatibility with black
   E265,  # Block comment should start with '# '
   E501,  # long lines
   E302  # Expected 2 blank lines, found 0

--- a/.flake8
+++ b/.flake8
@@ -2,8 +2,7 @@
 ignore =
   W503,  # line break before binary operator. Deactivated because of incompatibility with black
   E265,  # Block comment should start with '# '
-  E501,  # long lines
-  E302  # Expected 2 blank lines, found 0
+  E501  # long lines
 max_line_length = 120
 import_order_style = appnexus
 application_package_names = src

--- a/.flake8
+++ b/.flake8
@@ -5,7 +5,6 @@ ignore =
   # W503 line break before binary operator. Deactivated because of incompatibility with black
   W503,
   # Personal taste
-  E252,
   E701,
   # Don't be too strict
   E265,  # Block comment should start with '# '

--- a/src/analyses/reliability/location/location_utils.py
+++ b/src/analyses/reliability/location/location_utils.py
@@ -46,7 +46,7 @@ def draw_polygon(ax: axes._base._AxesBase, polygon: Polygon):
     poly_gdf.boundary.plot(ax=ax, color="red")
 
 
-def draw_distributions(series: List[pd.Series], labels: List[str], caption: str=""):
+def draw_distributions(series: List[pd.Series], labels: List[str], caption: str = ""):
     plt.figure(figsize=(20, 7))
     bins = np.linspace(0, 20, 50)
     for s, label in zip(series, labels):

--- a/src/common/evaluation/QA/eval-standardisation-test/src/utils.py
+++ b/src/common/evaluation/QA/eval-standardisation-test/src/utils.py
@@ -195,6 +195,7 @@ def setWidth(value):
     global width
     width = value
 
+
 def setHeight(value):
     global height
     height = value

--- a/src/common/model_utils/preprocessing.py
+++ b/src/common/model_utils/preprocessing.py
@@ -13,6 +13,7 @@ REGEX_PICKLE = re.compile(
     r"pc_(?P<qrcode>[a-zA-Z0-9]+-[a-zA-Z0-9]+)_(?P<unixepoch>\d+)_(?P<code>\d{3})_(?P<idx>\d{3}).p$"
 )
 
+
 def create_samples(qrcode_paths: List[str], CONFIG) -> List[List[str]]:
     samples = []
     for qrcode_path in sorted(qrcode_paths):

--- a/src/common/result_generation/tests/test_blur.py
+++ b/src/common/result_generation/tests/test_blur.py
@@ -7,6 +7,7 @@ from blur import blur_faces_in_file  # noqa: E402
 
 IMAGE_FNAME = "rgb_1583438117-71v1y4z0gd_1592711198959_101_74947.76209955901.jpg"
 
+
 def test_blur_faces_in_file():
     source_path = str(Path(__file__).parent / IMAGE_FNAME)
     target_path = str(Path('/tmp') / f"{IMAGE_FNAME}_blurred.jpg")

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/model.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/model.py
@@ -30,7 +30,7 @@ def download_pretrained_model(workspace: Workspace, output_model_fpath: str):
     previous_run.download_file(f"outputs/{MODEL_H5_FILENAME}", output_model_fpath)
 
 
-def load_base_cgm_model(model_fpath: str, should_freeze: bool=False) -> models.Sequential:
+def load_base_cgm_model(model_fpath: str, should_freeze: bool = False) -> models.Sequential:
     # load model
     loaded_model = models.load_model(model_fpath)
 


### PR DESCRIPTION
In the beginning of cgm-ml, we needed to setup a lightweight check. Now the repo has matured and we can follow pep8 more closely

Re-Enable:
- E252 missing whitespace around parameter equals
- I100 import order
- I101 import order
- E701
- E302: Expected 2 blank lines, found 1