### PR TITLE
Speed up flake8 check

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,13 +32,14 @@ steps:
     path: $(PIP_CACHE_DIR)
   displayName: Cache pip packages
 - script: |
+    pip install flake8==3.8.4
+    flake8 src/
+  displayName: 'flake8'
+- script: |
     python -m pip install --upgrade pip
     pip install setuptools==50.3.2
     pip install -r requirements.txt
   displayName: 'Install dependencies'
-- script: |
-    flake8 src/
-  displayName: 'flake8'
 - script: |
     pytest --cov=src
   displayName: 'pytest'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,6 +23,10 @@ steps:
   inputs:
     versionSpec: '$(python.version)'
   displayName: 'Use Python $(python.version)'
+- script: |
+    pip install flake8==3.8.4
+    flake8 src/
+  displayName: 'flake8'
 - task: Cache@2
   inputs:
     key: 'python | "$(Agent.OS)" | requirements.txt'
@@ -31,10 +35,6 @@ steps:
       python
     path: $(PIP_CACHE_DIR)
   displayName: Cache pip packages
-- script: |
-    pip install flake8==3.8.4
-    flake8 src/
-  displayName: 'flake8'
 - script: |
     python -m pip install --upgrade pip
     pip install setuptools==50.3.2


### PR DESCRIPTION
**Motivation** If the azure pipeline fails due to flake8, this takes more then 10 minutes. 

**Solution**: Check flake8 before the time-consuming installing `pip install`