### PR TITLE
Remove double trigger

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -1,6 +1,6 @@
 name: Python package
 
-on: [push, pull_request]
+on: push
 
 jobs:
   build:


### PR DESCRIPTION
Problem: We trigger the build twice which is not necessary
![image](https://user-images.githubusercontent.com/1809832/102768214-18bfd780-4381-11eb-903d-dab99ef0bff0.png)

Solution: The `push` build will already show up in the PR.