### PR TITLE
Rename _front to _standingfront (and similar)

### DIFF
--- a/src/common/evaluation/QA/eval-standardisation-test/src/qa_config_height.py
+++ b/src/common/evaluation/QA/eval-standardisation-test/src/qa_config_height.py
@@ -54,14 +54,7 @@ DATA_CONFIG = Bunch(dict(
     # Parameters for dataset generation.
     TARGET_INDEXES=[0],  # 0 is height, 1 is weight.
 
-    CODE_TO_SCANTYPE={
-        '100': '_standingfront',
-        '101': '_standing360',
-        '102': '_standingback',
-        '200': '_lyingfront',
-        '201': '_lyingrot',
-        '202': '_lyingback',
-    }
+    CODES=['100', '101', '102', '200', '201', '202'],
 ))
 
 

--- a/src/common/evaluation/QA/eval-standardisation-test/src/qa_config_height.py
+++ b/src/common/evaluation/QA/eval-standardisation-test/src/qa_config_height.py
@@ -55,9 +55,9 @@ DATA_CONFIG = Bunch(dict(
     TARGET_INDEXES=[0],  # 0 is height, 1 is weight.
 
     CODE_TO_SCANTYPE={
-        '100': '_front',
-        '101': '_360',
-        '102': '_back',
+        '100': '_standingfront',
+        '101': '_standing360',
+        '102': '_standingback',
         '200': '_lyingfront',
         '201': '_lyingrot',
         '202': '_lyingback',

--- a/src/common/evaluation/QA/eval-standardisation-test/src/qa_config_weight.py
+++ b/src/common/evaluation/QA/eval-standardisation-test/src/qa_config_weight.py
@@ -54,14 +54,7 @@ DATA_CONFIG = Bunch(dict(
     # Parameters for dataset generation.
     TARGET_INDEXES=[0],  # 0 is height, 1 is weight.
 
-    CODE_TO_SCANTYPE={
-        '100': '_standingfront',
-        '101': '_standing360',
-        '102': '_standingback',
-        '200': '_lyingfront',
-        '201': '_lyingrot',
-        '202': '_lyingback',
-    }
+    CODES=['100', '101', '102', '200', '201', '202']
 ))
 
 

--- a/src/common/evaluation/QA/eval-standardisation-test/src/qa_config_weight.py
+++ b/src/common/evaluation/QA/eval-standardisation-test/src/qa_config_weight.py
@@ -55,9 +55,9 @@ DATA_CONFIG = Bunch(dict(
     TARGET_INDEXES=[0],  # 0 is height, 1 is weight.
 
     CODE_TO_SCANTYPE={
-        '100': '_front',
-        '101': '_360',
-        '102': '_back',
+        '100': '_standingfront',
+        '101': '_standing360',
+        '102': '_standingback',
         '200': '_lyingfront',
         '201': '_lyingrot',
         '202': '_lyingback',

--- a/src/common/evaluation/QA/eval-standardisation-test/src/utils.py
+++ b/src/common/evaluation/QA/eval-standardisation-test/src/utils.py
@@ -28,6 +28,15 @@ permissible_measure = {'HEIGHT':
                        {'GOOD': 2.0, 'ACCEPTABLE': 2.7, 'POOR': 3.3, 'REJECT': None}
                        }
 
+CODE_TO_SCANTYPE = {
+    '100': '_standingfront',
+    '101': '_standing360',
+    '102': '_standingback',
+    '200': '_lyingfront',
+    '201': '_lyingrot',
+    '202': '_lyingback',
+}
+
 
 def get_intra_TEM(measure_one, measure_two):
     '''
@@ -127,9 +136,9 @@ def calculate_and_save_results(MAE, complete_name, CSV_OUT_PATH):
     Calculate accuracies across the scantypes
     '''
     dfs = []
-    for code in DATA_CONFIG.CODE_TO_SCANTYPE.keys():
+    for code in DATA_CONFIG.CODES:
         df = calculate_performance(code, MAE)
-        full_model_name = complete_name + DATA_CONFIG.CODE_TO_SCANTYPE[code]
+        full_model_name = complete_name + CODE_TO_SCANTYPE[code]
         df.rename(index={0: full_model_name}, inplace=True)
         #display(HTML(df.to_html()))
         dfs.append(df)

--- a/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_42c4ef33.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_42c4ef33.py
@@ -41,14 +41,7 @@ DATA_CONFIG = Bunch(dict(
     # Parameters for dataset generation.
     TARGET_INDEXES=[0, 3, 4, 5],  # 0 is height, 1 is weight, 2 is muac, 3 is weight, 4 is sex('male' or 'female'), 5 is quality ('good' or 'bad'), 6 is test
 
-    CODE_TO_SCANTYPE={
-        '100': '_standingfront',
-        '101': '_standing360',
-        '102': '_standingback',
-        '200': '_lyingfront',
-        '201': '_lyingrot',
-        '202': '_lyingback',
-    }
+    CODES=['100', '101', '102', '200', '201', '202']
 ))
 
 #Result configuration for result generation after evaluation is done

--- a/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_42c4ef33.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_42c4ef33.py
@@ -42,9 +42,9 @@ DATA_CONFIG = Bunch(dict(
     TARGET_INDEXES=[0, 3, 4, 5],  # 0 is height, 1 is weight, 2 is muac, 3 is weight, 4 is sex('male' or 'female'), 5 is quality ('good' or 'bad'), 6 is test
 
     CODE_TO_SCANTYPE={
-        '100': '_front',
-        '101': '_360',
-        '102': '_back',
+        '100': '_standingfront',
+        '101': '_standing360',
+        '102': '_standingback',
         '200': '_lyingfront',
         '201': '_lyingrot',
         '202': '_lyingback',

--- a/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_cb44f6db.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_cb44f6db.py
@@ -45,9 +45,9 @@ DATA_CONFIG = Bunch(dict(
     TARGET_INDEXES=[0, 3, 4, 5],  # 0 is height, 1 is weight, 2 is muac, 3 is weight, 4 is sex('male' or 'female'), 5 is quality ('good' or 'bad'), 6 is test
 
     CODE_TO_SCANTYPE={
-        '100': '_front',
-        '101': '_360',
-        '102': '_back',
+        '100': '_standingfront',
+        '101': '_standing360',
+        '102': '_standingback',
         '200': '_lyingfront',
         '201': '_lyingrot',
         '202': '_lyingback',

--- a/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_cb44f6db.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_cb44f6db.py
@@ -44,14 +44,7 @@ DATA_CONFIG = Bunch(dict(
     # Parameters for dataset generation.
     TARGET_INDEXES=[0, 3, 4, 5],  # 0 is height, 1 is weight, 2 is muac, 3 is weight, 4 is sex('male' or 'female'), 5 is quality ('good' or 'bad'), 6 is test
 
-    CODE_TO_SCANTYPE={
-        '100': '_standingfront',
-        '101': '_standing360',
-        '102': '_standingback',
-        '200': '_lyingfront',
-        '201': '_lyingrot',
-        '202': '_lyingback',
-    }
+    CODES=['100', '101', '102', '200', '201', '202']
 ))
 
 

--- a/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_height.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_height.py
@@ -44,14 +44,7 @@ DATA_CONFIG = Bunch(dict(
     # Parameters for dataset generation.
     TARGET_INDEXES=[0],  # 0 is height, 1 is weight.
 
-    CODE_TO_SCANTYPE={
-        '100': '_standingfront',
-        '101': '_standing360',
-        '102': '_standingback',
-        '200': '_lyingfront',
-        '201': '_lyingrot',
-        '202': '_lyingback',
-    }
+    CODES=['100', '101', '102', '200', '201', '202']
 ))
 
 

--- a/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_height.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_height.py
@@ -45,9 +45,9 @@ DATA_CONFIG = Bunch(dict(
     TARGET_INDEXES=[0],  # 0 is height, 1 is weight.
 
     CODE_TO_SCANTYPE={
-        '100': '_front',
-        '101': '_360',
-        '102': '_back',
+        '100': '_standingfront',
+        '101': '_standing360',
+        '102': '_standingback',
         '200': '_lyingfront',
         '201': '_lyingrot',
         '202': '_lyingback',

--- a/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_weight.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_weight.py
@@ -42,9 +42,9 @@ DATA_CONFIG = Bunch(dict(
     TARGET_INDEXES=[1],  # 0 is height, 1 is weight.
 
     CODE_TO_SCANTYPE={
-        '100': '_front',
-        '101': '_360',
-        '102': '_back',
+        '100': '_standingfront',
+        '101': '_standing360',
+        '102': '_standingback',
         '200': '_lyingfront',
         '201': '_lyingrot',
         '202': '_lyingback',

--- a/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_weight.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_weight.py
@@ -41,14 +41,7 @@ DATA_CONFIG = Bunch(dict(
     # Parameters for dataset generation.
     TARGET_INDEXES=[1],  # 0 is height, 1 is weight.
 
-    CODE_TO_SCANTYPE={
-        '100': '_standingfront',
-        '101': '_standing360',
-        '102': '_standingback',
-        '200': '_lyingfront',
-        '201': '_lyingrot',
-        '202': '_lyingback',
-    }
+    CODES=['100', '101', '102', '200', '201', '202']
 ))
 
 

--- a/src/common/evaluation/QA/eval_depthmap_models/src/utils.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/utils.py
@@ -23,6 +23,15 @@ GOODBAD_IDX = 5
 SEX_DICT = {'female': 0., 'male': 1.}
 GOODBAD_DICT = {'bad': 0., 'good': 1.}
 
+CODE_TO_SCANTYPE = {
+    '100': '_standingfront',
+    '101': '_standing360',
+    '102': '_standingback',
+    '200': '_lyingfront',
+    '201': '_lyingrot',
+    '202': '_lyingback',
+}
+
 
 def download_dataset(workspace: Workspace, dataset_name: str, dataset_path: str):
     print("Accessing dataset...")
@@ -129,9 +138,9 @@ def calculate_and_save_results(MAE: pd.DataFrame, complete_name: str, CSV_OUT_FP
         fct: Function to execute on inputs
     """
     dfs = []
-    for code in DATA_CONFIG.CODE_TO_SCANTYPE.keys():
+    for code in DATA_CONFIG.CODES:
         df = fct(code, MAE, RESULT_CONFIG)
-        full_model_name = complete_name + DATA_CONFIG.CODE_TO_SCANTYPE[code]
+        full_model_name = complete_name + CODE_TO_SCANTYPE[code]
         df.rename(index={0: full_model_name}, inplace=True)
         dfs.append(df)
 

--- a/src/common/evaluation/eval_utils.py
+++ b/src/common/evaluation/eval_utils.py
@@ -13,9 +13,9 @@ EVALUATION_ACCURACIES = [.2, .4, .8, 1.2, 2., 2.5, 3., 4., 5., 6.]
 MODEL_CKPT_FILENAME = "best_model.ckpt"
 
 CODE_TO_SCANTYPE = {
-    '100': '_front',
-    '101': '_360',
-    '102': '_back',
+    '100': '_standingfront',
+    '101': '_standing360',
+    '102': '_standingback',
     '200': '_lyingfront',
     '201': '_lyingrot',
     '202': '_lyingback',


### PR DESCRIPTION
Motivation: CSV files that we output should be readable by stakeholders.

Changes
- reduce places where names are repeated
- rename:
    - Rename '_front' to '_standingfront'
    - Rename '_360' to '_standing360'
    - Rename '_back' to '_standingback'