### PR TITLE
Exclude broken unit test

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-addopts = -p no:warnings
+addopts = -p no:warnings --ignore=src/data_utils/dataset_generation/tests/test_create_dataset.py
 testpaths =
     src/


### PR DESCRIPTION
**Problem:** 
- unit tests are accessing Azure resources (a postgres database), but they should be independent of internet access
- therefore unit tests can not just be run locally

**Solution:** 
- Ignore dataset test
- this test can be added back later if it doesn't require internet access

Also this is faster in CI:
- [before](https://github.com/Welthungerhilfe/cgm-ml/runs/1682627546) duration: `7min11sec` 
- after duration: `39sec`

