### PR TITLE
Rename master to main in codebase

### DIFF
--- a/src/common/zscore/azure-pipelines.yml
+++ b/src/common/zscore/azure-pipelines.yml
@@ -1,7 +1,7 @@
 trigger:
   branches:
     include:
-    - master
+    - main
     - releases/*
   paths:
     include:


### PR DESCRIPTION
Motivation: [github has renamed master branch to main branch](https://github.com/github/renaming). In order to be consistent, we will rename, too.

For individual contributors: You can update your local setup like this:
![image](https://user-images.githubusercontent.com/1809832/104437588-44546d00-558f-11eb-966a-717b635ea0b9.png)
