### PR TITLE
Enable eval pipeline in new tenant

### DIFF
--- a/src/common/evaluation/QA/environment.yml
+++ b/src/common/evaluation/QA/environment.yml
@@ -2,6 +2,8 @@ name: CGM_QA_Pipeline
 channels:
   - conda-forge
 dependencies:
+  - setuptools
+  - wheel
   - python=3.7
   - pip
   - nb_conda_kernels==2.2.1

--- a/src/common/evaluation/QA/environment.yml
+++ b/src/common/evaluation/QA/environment.yml
@@ -2,8 +2,8 @@ name: CGM_QA_Pipeline
 channels:
   - conda-forge
 dependencies:
-  - setuptools
-  - wheel
+  - setuptools=50.3.0
+  - wheel=0.35.1
   - python=3.7
   - pip
   - nb_conda_kernels==2.2.1

--- a/src/common/evaluation/QA/eval_depthmap_models/eval_configs.sh
+++ b/src/common/evaluation/QA/eval_depthmap_models/eval_configs.sh
@@ -3,7 +3,7 @@
 set -euox pipefail
 
 python eval_main.py --qa_config_module qa_config_42c4ef33
-# python eval_main.py --qa_config_module qa_config_cb44f6db
+python eval_main.py --qa_config_module qa_config_cb44f6db
 # python eval_main.py --qa_config_module qa_config_filter
 # python eval_main.py --qa_config_module qa_config_height
 # python eval_main.py --qa_config_module qa_config_weight

--- a/src/common/evaluation/QA/eval_depthmap_models/eval_configs.sh
+++ b/src/common/evaluation/QA/eval_depthmap_models/eval_configs.sh
@@ -3,7 +3,7 @@
 set -euox pipefail
 
 python eval_main.py --qa_config_module qa_config_42c4ef33
-python eval_main.py --qa_config_module qa_config_cb44f6db
-python eval_main.py --qa_config_module qa_config_filter
+# python eval_main.py --qa_config_module qa_config_cb44f6db
+# python eval_main.py --qa_config_module qa_config_filter
 # python eval_main.py --qa_config_module qa_config_height
 # python eval_main.py --qa_config_module qa_config_weight

--- a/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_42c4ef33.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_42c4ef33.py
@@ -2,29 +2,29 @@ from bunch import Bunch
 
 # Details of model used for evaluation
 MODEL_CONFIG = Bunch(dict(
-    EXPERIMENT_NAME='q3-depthmap-plaincnn-height-95k',
+    EXPERIMENT_NAME='q1-ensemble-warmup',
 
-    RUN_ID='q3-depthmap-plaincnn-height-95k_1597988908_42c4ef33',  # Run 3
+    RUN_ID='q1-ensemble-warmup_1610544610_eb44bfe2',  # Run 3
     # RUN_ID='q3-depthmap-plaincnn-height-95k_1600451633_cb44f6db',  #Run 17
 
     INPUT_LOCATION='outputs',
-    NAME='best_model.h5',
+    NAME='best_model.ckpt',
 ))
 
 
 EVAL_CONFIG = Bunch(dict(
     # Name of evaluation
-    NAME='q3-depthmap-plaincnn-height-95k_run_03',
+    NAME='q1-ensemble-warmup_run_01',
 
     # Experiment in Azure ML which will be used for evaluation
     EXPERIMENT_NAME="QA-pipeline",
     CLUSTER_NAME="gpu-cluster",
 
     # Used for Debug the QA pipeline
-    DEBUG_RUN=False,
+    DEBUG_RUN=True,
 
     # Will run eval on specified # of scan instead of full dataset
-    DEBUG_NUMBER_OF_SCAN=5,
+    DEBUG_NUMBER_OF_SCAN=100,
 
     SPLIT_SEED=0,
 ))

--- a/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_42c4ef33.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_42c4ef33.py
@@ -2,10 +2,8 @@ from bunch import Bunch
 
 # Details of model used for evaluation
 MODEL_CONFIG = Bunch(dict(
-    EXPERIMENT_NAME='q1-ensemble-warmup',
-
-    RUN_ID='q1-ensemble-warmup_1610544610_eb44bfe2',  # Run 3
-    # RUN_ID='q3-depthmap-plaincnn-height-95k_1600451633_cb44f6db',  #Run 17
+    EXPERIMENT_NAME='q3-depthmap-plaincnn-height-95k',
+    RUN_ID='q3-depthmap-plaincnn-height-95k_1610709869_2e00a6ef',  # Run 4
 
     INPUT_LOCATION='outputs',
     NAME='best_model.ckpt',
@@ -14,17 +12,17 @@ MODEL_CONFIG = Bunch(dict(
 
 EVAL_CONFIG = Bunch(dict(
     # Name of evaluation
-    NAME='q1-ensemble-warmup_run_01',
+    NAME='q3-depthmap-plaincnn-height-95k_run_04',
 
     # Experiment in Azure ML which will be used for evaluation
     EXPERIMENT_NAME="QA-pipeline",
     CLUSTER_NAME="gpu-cluster",
 
     # Used for Debug the QA pipeline
-    DEBUG_RUN=True,
+    DEBUG_RUN=False,
 
     # Will run eval on specified # of scan instead of full dataset
-    DEBUG_NUMBER_OF_SCAN=90,
+    DEBUG_NUMBER_OF_SCAN=5,
 
     SPLIT_SEED=0,
 ))

--- a/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_42c4ef33.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_42c4ef33.py
@@ -24,7 +24,7 @@ EVAL_CONFIG = Bunch(dict(
     DEBUG_RUN=True,
 
     # Will run eval on specified # of scan instead of full dataset
-    DEBUG_NUMBER_OF_SCAN=100,
+    DEBUG_NUMBER_OF_SCAN=90,
 
     SPLIT_SEED=0,
 ))

--- a/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_cb44f6db.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_cb44f6db.py
@@ -3,18 +3,16 @@ from bunch import Bunch
 # Details of model used for evaluation
 MODEL_CONFIG = Bunch(dict(
     EXPERIMENT_NAME='q3-depthmap-plaincnn-height-95k',
-
-    # RUN_ID='q3-depthmap-plaincnn-height-95k_1597988908_42c4ef33',  # Run 3
-    RUN_ID='q3-depthmap-plaincnn-height-95k_1600451633_cb44f6db',  # Run 17
+    RUN_ID='q3-depthmap-plaincnn-height-95k_1610709896_ef7f755d',  # Run 5
 
     INPUT_LOCATION='outputs',
-    NAME='best_model.h5',
+    NAME='best_model.ckpt',
 ))
 
 
 EVAL_CONFIG = Bunch(dict(
     # Name of evaluation
-    NAME='q3-depthmap-plaincnn-height-95k_run_04',
+    NAME='q3-depthmap-plaincnn-height-95k_run_05',
 
     # Experiment in Azure ML which will be used for evaluation
     EXPERIMENT_NAME="QA-pipeline",

--- a/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_filter.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_filter.py
@@ -6,7 +6,7 @@ MODEL_CONFIG = Bunch(dict(
     RUN_ID='q3-depthmap-plaincnn-height-95k_1597988908_42c4ef33',  # Run 3
 
     INPUT_LOCATION='outputs',
-    NAME='best_model.h5',
+    NAME='best_model.ckpt',
 ))
 
 FILTER_CONFIG = Bunch(dict(

--- a/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_filter.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_filter.py
@@ -3,9 +3,7 @@ from bunch import Bunch
 # Details of model used for evaluation
 MODEL_CONFIG = Bunch(dict(
     EXPERIMENT_NAME='q3-depthmap-plaincnn-height-95k',
-
     RUN_ID='q3-depthmap-plaincnn-height-95k_1597988908_42c4ef33',  # Run 3
-    # RUN_ID = 'q3-depthmap-plaincnn-height-95k_1600451633_cb44f6db',     #Run 17
 
     INPUT_LOCATION='outputs',
     NAME='best_model.h5',

--- a/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_height.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_height.py
@@ -3,9 +3,7 @@ from bunch import Bunch
 # Details of model used for evaluation
 MODEL_CONFIG = Bunch(dict(
     EXPERIMENT_NAME='q3-depthmap-plaincnn-height-95k',
-
-    # RUN_ID='q3-depthmap-plaincnn-height-95k_1597988908_42c4ef33',  # Run 3
-    RUN_ID='q3-depthmap-plaincnn-height-95k_1600451633_cb44f6db',  # Run 17
+    RUN_ID='q3-depthmap-plaincnn-height-95k_1610709896_ef7f755d',  # Run 5
 
     INPUT_LOCATION='outputs',
     NAME='best_model.h5',

--- a/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_height.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_height.py
@@ -6,7 +6,7 @@ MODEL_CONFIG = Bunch(dict(
     RUN_ID='q3-depthmap-plaincnn-height-95k_1610709896_ef7f755d',  # Run 5
 
     INPUT_LOCATION='outputs',
-    NAME='best_model.h5',
+    NAME='best_model.ckpt',
 ))
 
 

--- a/src/common/evaluation/QA/test-pipeline.yml
+++ b/src/common/evaluation/QA/test-pipeline.yml
@@ -3,8 +3,6 @@ trigger:
     include:
     - releases/*
 
-pr: none
-
 jobs:
 - job: EvaluationJob
   timeoutInMinutes: 300

--- a/src/common/evaluation/QA/test-pipeline.yml
+++ b/src/common/evaluation/QA/test-pipeline.yml
@@ -3,6 +3,8 @@ trigger:
     include:
     - releases/*
 
+pr: none
+
 jobs:
 - job: EvaluationJob
   timeoutInMinutes: 300


### PR DESCRIPTION
**Status quo:** We changed Service connection / Service Principle to the new tenant. Now the pipeline will always run in the new tenant. 

**Changes:**
- `setuptools` and `wheel` are needed now otherwise the conda installation in the AzureML docker build fails
- run experiements again in new tenant (they get new run IDs)
- change experiment names and run ids so they get found in the new tenant
- Disable filter config because it would not yet work

Future work: we have to bring the standing/lying classification model in the new tenant so we can reference it in the pipeline again (@prajurock )