### PR TITLE
Put pip packages to constants.py instead of notebook

### DIFF
--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/src/constants.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/src/constants.py
@@ -3,3 +3,12 @@ from pathlib import Path
 REPO_DIR = Path(__file__).parents[6].absolute()
 DATA_DIR_ONLINE_RUN = Path("/tmp/data/")
 MODEL_CKPT_FILENAME = "best_model.ckpt"
+
+PIP_PACKAGES = [
+    "azureml-dataprep[fuse,pandas]",
+    "glob2",
+    "opencv-python==4.1.2.30",
+    "matplotlib",
+    "tensorflow-addons==0.11.2",
+    "bunch==1.0.1",
+]

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/train_notebook.ipynb
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/train_notebook.ipynb
@@ -34,7 +34,7 @@
     "import os\n",
     "import shutil\n",
     "\n",
-    "from src.constants import REPO_DIR"
+    "from src.constants import REPO_DIR, PIP_PACKAGES"
    ]
   },
   {
@@ -265,15 +265,6 @@
    "outputs": [],
    "source": [
     "# Specify pip packages here.\n",
-    "pip_packages = [\n",
-    "    \"azureml-dataprep[fuse,pandas]\",\n",
-    "    \"glob2\",\n",
-    "    \"opencv-python==4.1.2.30\",\n",
-    "    \"matplotlib\",\n",
-    "    \"tensorflow-addons==0.11.2\",\n",
-    "    \"bunch==1.0.1\",\n",
-    "]\n",
-    "\n",
     "inputs = None    \n",
     "if CONFIG.DATASET_MODE == DATASET_MODE_MOUNT:\n",
     "    inputs = [dataset.as_named_input(\"dataset\").as_mount(\"/mnt/dataset\")]\n",
@@ -286,7 +277,7 @@
     "    use_gpu=True,\n",
     "    framework_version=\"2.3\",\n",
     "    inputs=inputs,\n",
-    "    pip_packages=pip_packages,\n",
+    "    pip_packages=PIP_PACKAGES,\n",
     "    script_params=script_params\n",
     ")\n",
     "\n",

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifact-plaincnn-height/src/constants.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifact-plaincnn-height/src/constants.py
@@ -1,3 +1,15 @@
 from pathlib import Path
+from src.models.CNNDepthMap.CNNDepthMap-height.q3-depthmap-plaincnn-height.src.constants import (
+    PIP_PACKAGES)
 
 REPO_DIR = Path(__file__).parents[6].absolute()
+
+PIP_PACKAGES = [
+    "azureml-dataprep[fuse,pandas]",
+    "glob2",
+    "opencv-python==4.1.2.30",
+    "matplotlib",
+    "imgaug==0.4.0",
+    "tensorflow-addons==0.11.2",
+    "bunch==1.0.1",
+]

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifact-plaincnn-height/src/constants.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifact-plaincnn-height/src/constants.py
@@ -1,6 +1,4 @@
 from pathlib import Path
-from src.models.CNNDepthMap.CNNDepthMap-height.q3-depthmap-plaincnn-height.src.constants import (
-    PIP_PACKAGES)
 
 REPO_DIR = Path(__file__).parents[6].absolute()
 

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifact-plaincnn-height/train_notebook.ipynb
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifact-plaincnn-height/train_notebook.ipynb
@@ -31,7 +31,9 @@
     "from azureml.core import Workspace, Dataset\n",
     "from azureml.core import Experiment\n",
     "import os\n",
-    "import shutil"
+    "import shutil\n",
+    "\n",
+    "from src.constants import PIP_PACKAGES"
    ]
   },
   {
@@ -244,17 +246,6 @@
    },
    "outputs": [],
    "source": [
-    "# Specify pip packages here.\n",
-    "pip_packages = [\n",
-    "    \"azureml-dataprep[fuse,pandas]\",\n",
-    "    \"glob2\",\n",
-    "    \"opencv-python==4.1.2.30\",\n",
-    "    \"matplotlib\",\n",
-    "    \"imgaug==0.4.0\",\n",
-    "    \"tensorflow-addons==0.11.2\",\n",
-    "    \"bunch==1.0.1\",\n",
-    "]\n",
-    "\n",
     "# Create the estimator.\n",
     "estimator = TensorFlow(\n",
     "    source_directory=temp_path,\n",
@@ -263,7 +254,7 @@
     "    use_gpu=True,\n",
     "    framework_version=\"2.2\",\n",
     "    inputs=[dataset.as_named_input(\"dataset\").as_mount()],\n",
-    "    pip_packages=pip_packages,\n",
+    "    pip_packages=PIP_PACKAGES,\n",
     "    script_params=script_params,\n",
     ")\n",
     "\n",

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/constants.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/constants.py
@@ -4,3 +4,13 @@ REPO_DIR = Path(__file__).parents[6].absolute()
 DATA_DIR_ONLINE_RUN = Path("/tmp/data/")
 MODEL_H5_FILENAME = "best_model.h5"
 MODEL_CKPT_FILENAME = "best_model.ckpt"
+
+PIP_PACKAGES = [
+    "azureml-dataprep[fuse,pandas]",
+    "glob2",
+    "opencv-python==4.1.2.30",
+    "matplotlib",
+    "imgaug==0.4.0",
+    "tensorflow-addons==0.11.2",
+    "bunch==1.0.1",
+]

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/train_notebook.ipynb
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/train_notebook.ipynb
@@ -33,7 +33,7 @@
     "import os\n",
     "import shutil\n",
     "\n",
-    "from src.constants import REPO_DIR"
+    "from src.constants import REPO_DIR, PIP_PACKAGES"
    ]
   },
   {
@@ -263,17 +263,6 @@
    },
    "outputs": [],
    "source": [
-    "# Specify pip packages here.\n",
-    "pip_packages = [\n",
-    "    \"azureml-dataprep[fuse,pandas]\",\n",
-    "    \"glob2\",\n",
-    "    \"opencv-python==4.1.2.30\",\n",
-    "    \"matplotlib\",\n",
-    "    \"imgaug==0.4.0\",\n",
-    "    \"tensorflow-addons==0.11.2\",\n",
-    "    \"bunch==1.0.1\",\n",
-    "]\n",
-    "\n",
     "inputs = None    \n",
     "if CONFIG.DATASET_MODE == DATASET_MODE_MOUNT:\n",
     "    inputs = [dataset.as_named_input(\"dataset\").as_mount(\"/mnt/dataset\")]\n",

--- a/src/models/CNNDepthMap/CNNDepthMap-multitask/q4-depthmap-plaincnn-multitask/src/constants.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-multitask/q4-depthmap-plaincnn-multitask/src/constants.py
@@ -3,3 +3,12 @@ from pathlib import Path
 REPO_DIR = Path(__file__).parents[6].absolute()
 DATA_DIR_ONLINE_RUN = Path("/tmp/data/")
 MODEL_CKPT_FILENAME = "best_model.ckpt"
+
+PIP_PACKAGES = [
+    "azureml-dataprep[fuse,pandas]",
+    "glob2",
+    "opencv-python==4.1.2.30",
+    "matplotlib",
+    "tensorflow-addons==0.11.2",
+    "bunch==1.0.1",
+]

--- a/src/models/CNNDepthMap/CNNDepthMap-multitask/q4-depthmap-plaincnn-multitask/train_notebook.ipynb
+++ b/src/models/CNNDepthMap/CNNDepthMap-multitask/q4-depthmap-plaincnn-multitask/train_notebook.ipynb
@@ -34,7 +34,7 @@
     "import os\n",
     "import shutil\n",
     "\n",
-    "from src.constants import REPO_DIR"
+    "from src.constants import REPO_DIR, PIP_PACKAGES"
    ]
   },
   {
@@ -264,16 +264,6 @@
    },
    "outputs": [],
    "source": [
-    "# Specify pip packages here.\n",
-    "pip_packages = [\n",
-    "    \"azureml-dataprep[fuse,pandas]\",\n",
-    "    \"glob2\",\n",
-    "    \"opencv-python==4.1.2.30\",\n",
-    "    \"matplotlib\",\n",
-    "    \"tensorflow-addons==0.11.2\",\n",
-    "    \"bunch==1.0.1\",\n",
-    "]\n",
-    "\n",
     "inputs = None    \n",
     "if CONFIG.DATASET_MODE == DATASET_MODE_MOUNT:\n",
     "    inputs = [dataset.as_named_input(\"dataset\").as_mount(\"/mnt/dataset\")]\n",

--- a/src/models/Unsupervised/Autoencoder/q4-anomalydetection-ae/src/constants.py
+++ b/src/models/Unsupervised/Autoencoder/q4-anomalydetection-ae/src/constants.py
@@ -3,3 +3,13 @@ from pathlib import Path
 REPO_DIR = Path(__file__).parents[6].absolute()
 DATA_DIR_ONLINE_RUN = Path("/tmp/data/")
 MODEL_CKPT_FILENAME = "best_model.ckpt"
+
+PIP_PACKAGES = [
+    "azureml-dataprep[fuse,pandas]",
+    "glob2",
+    "tensorflow_datasets",
+    "opencv-python==4.1.2.30",
+    "matplotlib",
+    "imageio",
+    "sklearn"
+]

--- a/src/models/Unsupervised/Autoencoder/q4-anomalydetection-ae/train_notebook.ipynb
+++ b/src/models/Unsupervised/Autoencoder/q4-anomalydetection-ae/train_notebook.ipynb
@@ -34,7 +34,7 @@
     "import os\n",
     "import shutil\n",
     "\n",
-    "from src.constants import REPO_DIR"
+    "from src.constants import REPO_DIR, PIP_PACKAGES"
    ]
   },
   {
@@ -423,17 +423,6 @@
     }
    ],
    "source": [
-    "# Specify pip packages here.\n",
-    "pip_packages = [\n",
-    "    \"azureml-dataprep[fuse,pandas]\",\n",
-    "    \"glob2\",\n",
-    "    \"tensorflow_datasets\",\n",
-    "    \"opencv-python==4.1.2.30\",\n",
-    "    \"matplotlib\",\n",
-    "    \"imageio\",\n",
-    "    \"sklearn\"\n",
-    "]\n",
-    "\n",
     "inputs = None    \n",
     "if CONFIG.DATASET_MODE == DATASET_MODE_MOUNT:\n",
     "    inputs = [dataset.as_named_input(\"dataset\").as_mount(\"/mnt/dataset\")]\n",


### PR DESCRIPTION
**Motivation:** It is easy to miss to update pip requirements in notebooks. When using modules, it is easier to see changes in git and to find all occurrences in the code.