### PR TITLE
Percentage added in confusion matrix

### DIFF
--- a/src/common/evaluation/QA/eval_depthmap_models/src/utils.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/utils.py
@@ -329,17 +329,17 @@ def draw_stunting_diagnosis(df: pd.DataFrame, png_out_fpath: str):
         else:
             not_processed_data.append(row['qrcode'])
     data = confusion_matrix(actual_stunting, predicted_stunting)
-    T1,FP1,FP2,FN1,T2,FP3,FN2,FN3,T3=data.ravel()
-    sum=T1+FP1+FP2+FN1+T2+FP3+FN2+FN3+T3
-    T=((T1+T2+T3)/sum)*100
-    FP=((FP1+FP2+FP3)/sum)*100
-    FN=((FN1+FN2+FN3)/sum)*100
+    T1, FP1, FP2, FN1, T2, FP3, FN2, FN3, T3 = data.ravel()
+    sum = T1 + FP1 + FP2 + FN1 + T2 + FP3 + FN2 + FN3 + T3
+    T = ((T1 + T2 + T3) / sum) * 100
+    FP = ((FP1 + FP2 + FP3) / sum) * 100
+    FN = ((FN1 + FN2 + FN3) / sum) * 100
     fig = plt.figure(figsize=(15, 15))
     ax = fig.add_subplot(111)
     disp = ConfusionMatrixDisplay(confusion_matrix=data, display_labels=STUNTING_DIAGNOSIS)
-    disp.plot(cmap='Blues', values_format='d',ax=ax)
-    s="True:-"+str(round(T,2))+" False Positive:-"+str(round(FP,2))+" False Negative:-"+str(round(FN,2))
-    plt.text(0.5, 0.5,s, size=10,bbox=dict(boxstyle="square",facecolor='white'))
+    disp.plot(cmap='Blues', values_format='d', ax=ax)
+    s = "True:-" + str(round(T, 2)) + " False Positive:-" + str(round(FP, 2)) + " False Negative:-" + str(round(FN, 2))
+    plt.text(0.5, 0.5, s, size=10, bbox=dict(boxstyle="square", facecolor='white'))
     ax.set_title("Stunting Diagnosis")
     Path(png_out_fpath).parent.mkdir(parents=True, exist_ok=True)
     plt.savefig(png_out_fpath)

--- a/src/common/evaluation/QA/eval_depthmap_models/src/utils.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/utils.py
@@ -329,10 +329,18 @@ def draw_stunting_diagnosis(df: pd.DataFrame, png_out_fpath: str):
         else:
             not_processed_data.append(row['qrcode'])
     data = confusion_matrix(actual_stunting, predicted_stunting)
-    plt.rcParams.update({'font.size': 8})
+    T1,FP1,FP2,FN1,T2,FP3,FN2,FN3,T3=data.ravel()
+    sum=T1+FP1+FP2+FN1+T2+FP3+FN2+FN3+T3
+    T=((T1+T2+T3)/sum)*100
+    FP=((FP1+FP2+FP3)/sum)*100
+    FN=((FN1+FN2+FN3)/sum)*100
+    fig = plt.figure(figsize=(15, 15))
+    ax = fig.add_subplot(111)
     disp = ConfusionMatrixDisplay(confusion_matrix=data, display_labels=STUNTING_DIAGNOSIS)
-    disp.plot(cmap='Blues', values_format='d')
-    plt.title("Stunting Diagnosis")
+    disp.plot(cmap='Blues', values_format='d',ax=ax)
+    s="True:-"+str(round(T,2))+" False Positive:-"+str(round(FP,2))+" False Negative:-"+str(round(FN,2))
+    plt.text(0.5, 0.5,s, size=10,bbox=dict(boxstyle="square",facecolor='white'))
+    ax.set_title("Stunting Diagnosis")
     Path(png_out_fpath).parent.mkdir(parents=True, exist_ok=True)
     plt.savefig(png_out_fpath)
     plt.close()

--- a/src/common/evaluation/QA/eval_depthmap_models/src/utils.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/utils.py
@@ -330,7 +330,7 @@ def draw_stunting_diagnosis(df: pd.DataFrame, png_out_fpath: str):
             not_processed_data.append(row['qrcode'])
     data = confusion_matrix(actual_stunting, predicted_stunting)
     T1, FP1, FP2, FN1, T2, FP3, FN2, FN3, T3 = data.ravel()
-    sum = T1 + FP1 + FP2 + FN1 + T2 + FP3 + FN2 + FN3 + T3
+    sum = sum(T1, FP1, FP2, FN1, T2, FP3, FN2, FN3, T3)
     T = ((T1 + T2 + T3) / sum) * 100
     FP = ((FP1 + FP2 + FP3) / sum) * 100
     FN = ((FN1 + FN2 + FN3) / sum) * 100

--- a/src/common/evaluation/QA/eval_depthmap_models/src/utils.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/utils.py
@@ -338,7 +338,7 @@ def draw_stunting_diagnosis(df: pd.DataFrame, png_out_fpath: str):
     ax = fig.add_subplot(111)
     disp = ConfusionMatrixDisplay(confusion_matrix=data, display_labels=STUNTING_DIAGNOSIS)
     disp.plot(cmap='Blues', values_format='d', ax=ax)
-    s = "True:-" + str(round(T, 2)) + " False Positive:-" + str(round(FP, 2)) + " False Negative:-" + str(round(FN, 2))
+    s = f"True: {round(T, 2)} False Positive: {round(FP, 2)} False Negative: {round(FN, 2)}"
     plt.text(0.5, 0.5, s, size=10, bbox=dict(boxstyle="square", facecolor='white'))
     ax.set_title("Stunting Diagnosis")
     Path(png_out_fpath).parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
# Description

True, False Negative, False Positive added in stunting confusion matrix.

User story #[ (US link)](https://dev.azure.com/cgmorg/ChildGrowthMonitor/_workitems/edit/770)

#Result
![image](https://user-images.githubusercontent.com/26791135/105415489-c6632680-5c5e-11eb-92d3-3ab9ba06cb65.png)



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests
- [ ] New and existing unit tests pass locally with my changes
- [ ] My Code is review by 1 People
