### PR TITLE
Weight model in new tenant

### DIFF
--- a/src/common/evaluation/QA/eval_depthmap_models/eval_configs.sh
+++ b/src/common/evaluation/QA/eval_depthmap_models/eval_configs.sh
@@ -6,4 +6,5 @@ python eval_main.py --qa_config_module qa_config_height_no_dropout
 python eval_main.py --qa_config_module qa_config_height_dropout
 # python eval_main.py --qa_config_module qa_config_filter
 # python eval_main.py --qa_config_module qa_config_height
-# python eval_main.py --qa_config_module qa_config_weight
+python eval_main.py --qa_config_module qa_config_weight_no_dropout
+python eval_main.py --qa_config_module qa_config_weight_dropout

--- a/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_filter.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_filter.py
@@ -58,7 +58,7 @@ RESULT_CONFIG = Bunch(dict(
     # Error margin on various ranges
     #EVALUATION_ACCURACIES = [.2, .4, .8, 1.2, 2., 2.5, 3., 4., 5., 6.]
     ACCURACIES=[.2, .4, .6, 1., 1.2, 2., 2.5, 3., 4., 5., 6.],  # 0.2cm, 0.4cm, 0.6cm, 1cm, ...
-    ACCURACY_MAIN_HEIGHT_THRESH=1.0,  # 1cm
+    ACCURACY_MAIN_THRESH=1.0,  # 1cm
     AGE_BUCKETS=[0, 1, 2, 3, 4, 5],
 
     COLUMNS=['qrcode', 'artifact', 'scantype', 'GT', 'predicted'],

--- a/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_height_dropout.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_height_dropout.py
@@ -4,7 +4,6 @@ from bunch import Bunch
 MODEL_CONFIG = Bunch(dict(
     EXPERIMENT_NAME='q3-depthmap-plaincnn-height-95k',
     RUN_ID='q3-depthmap-plaincnn-height-95k_1610709896_ef7f755d',  # Run 5
-
     INPUT_LOCATION='outputs',
     NAME='best_model.ckpt',
 ))
@@ -45,7 +44,6 @@ DATA_CONFIG = Bunch(dict(
 #Result configuration for result generation after evaluation is done
 RESULT_CONFIG = Bunch(dict(
     # Error margin on various ranges
-    # EVALUATION_ACCURACIES = [.2, .4, .8, 1.2, 2., 2.5, 3., 4., 5., 6.]
     ACCURACIES=[.2, .4, .6, 1., 1.2, 2., 2.5, 3., 4., 5., 6.],  # 0.2cm, 0.4cm, 0.6cm, 1cm, ...
     ACCURACY_MAIN_HEIGHT_THRESH=1.0,  # 1cm
     AGE_BUCKETS=[0, 1, 2, 3, 4, 5],

--- a/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_height_dropout.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_height_dropout.py
@@ -45,7 +45,7 @@ DATA_CONFIG = Bunch(dict(
 RESULT_CONFIG = Bunch(dict(
     # Error margin on various ranges
     ACCURACIES=[.2, .4, .6, 1., 1.2, 2., 2.5, 3., 4., 5., 6.],  # 0.2cm, 0.4cm, 0.6cm, 1cm, ...
-    ACCURACY_MAIN_HEIGHT_THRESH=1.0,  # 1cm
+    ACCURACY_MAIN_THRESH=1.0,  # 1cm
     AGE_BUCKETS=[0, 1, 2, 3, 4, 5],
 
     COLUMNS=['qrcode', 'artifact', 'scantype', 'GT', 'predicted'],

--- a/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_height_no_dropout.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_height_no_dropout.py
@@ -44,7 +44,7 @@ DATA_CONFIG = Bunch(dict(
 RESULT_CONFIG = Bunch(dict(
     # Error margin on various ranges
     ACCURACIES=[.2, .4, .6, 1., 1.2, 2., 2.5, 3., 4., 5., 6.],  # 0.2cm, 0.4cm, 0.6cm, 1cm, ...
-    ACCURACY_MAIN_HEIGHT_THRESH=1.0,  # 1cm
+    ACCURACY_MAIN_THRESH=1.0,  # 1cm
     AGE_BUCKETS=[0, 1, 2, 3, 4, 5],
 
     COLUMNS=['qrcode', 'artifact', 'scantype', 'GT', 'predicted'],

--- a/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_weight.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_weight.py
@@ -2,7 +2,7 @@ from bunch import Bunch
 
 # Details of model used for evaluation
 MODEL_CONFIG = Bunch(dict(
-    EXPERIMENT_NAME='q4-depthmap-plaincnn-weight-95k',
+    EXPERIMENT_NAME='q4-depthmap-plaincnn-weight-95k', # TODO
     RUN_ID='q4-depthmap-plaincnn-weight-95k_1605774694_c216f6c5',
     INPUT_LOCATION='outputs',
     NAME='best_model.ckpt',
@@ -11,7 +11,7 @@ MODEL_CONFIG = Bunch(dict(
 
 EVAL_CONFIG = Bunch(dict(
     # Name of evaluation
-    NAME='q4-depthmap-plaincnn-weight-95k-run_12',
+    NAME='q4-depthmap-plaincnn-weight-95k-run_12',  # TODO
 
     # Experiment in Azure ML which will be used for evaluation
     EXPERIMENT_NAME="QA-pipeline",

--- a/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_weight_dropout.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_weight_dropout.py
@@ -45,7 +45,7 @@ DATA_CONFIG = Bunch(dict(
 RESULT_CONFIG = Bunch(dict(
     # Error margin on various ranges
     ACCURACIES=[0.04, 0.1, 0.21, 0.42],  # 0.2cm, 0.4cm, 0.6cm, 1cm, ...
-    ACCURACY_MAIN_WEIGHT_THRESH=210,  # 210gms
+    ACCURACY_MAIN_THRESH=210,  # 210gms
     AGE_BUCKETS=[0, 1, 2, 3, 4, 5],
 
     COLUMNS=['qrcode', 'artifact', 'scantype', 'GT', 'predicted'],

--- a/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_weight_dropout.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_weight_dropout.py
@@ -44,7 +44,7 @@ DATA_CONFIG = Bunch(dict(
 #Result configuration for result generation after evaluation is done
 RESULT_CONFIG = Bunch(dict(
     # Error margin on various ranges
-    ACCURACIES=[.2, .4, .6, 1., 1.2, 2., 2.5, 3., 4., 5., 6.],  # 0.2cm, 0.4cm, 0.6cm, 1cm, ...
+    ACCURACIES=[0.04, 0.1, 0.21, 0.42],  # 0.2cm, 0.4cm, 0.6cm, 1cm, ...
     ACCURACY_MAIN_WEIGHT_THRESH=210,  # 210gms
     AGE_BUCKETS=[0, 1, 2, 3, 4, 5],
 

--- a/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_weight_dropout.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_weight_dropout.py
@@ -2,8 +2,8 @@ from bunch import Bunch
 
 # Details of model used for evaluation
 MODEL_CONFIG = Bunch(dict(
-    EXPERIMENT_NAME='q3-depthmap-plaincnn-height-95k',
-    RUN_ID='q3-depthmap-plaincnn-height-95k_1610709869_2e00a6ef',  # Run 4
+    EXPERIMENT_NAME='q4-depthmap-plaincnn-weight-95k',
+    RUN_ID='q4-depthmap-plaincnn-weight-95k_1611336518_642a9c58',
     INPUT_LOCATION='outputs',
     NAME='best_model.ckpt',
 ))
@@ -11,7 +11,7 @@ MODEL_CONFIG = Bunch(dict(
 
 EVAL_CONFIG = Bunch(dict(
     # Name of evaluation
-    NAME='q3-depthmap-plaincnn-height-95k_run_04',
+    NAME='q4-depthmap-plaincnn-weight-95k_run_02',
 
     # Experiment in Azure ML which will be used for evaluation
     EXPERIMENT_NAME="QA-pipeline",
@@ -21,7 +21,7 @@ EVAL_CONFIG = Bunch(dict(
     DEBUG_RUN=False,
 
     # Will run eval on specified # of scan instead of full dataset
-    DEBUG_NUMBER_OF_SCAN=25,
+    DEBUG_NUMBER_OF_SCAN=5,
 
     SPLIT_SEED=0,
 ))
@@ -36,15 +36,16 @@ DATA_CONFIG = Bunch(dict(
     BATCH_SIZE=512,  # Batch size for evaluation
     NORMALIZATION_VALUE=7.5,
 
-    TARGET_INDEXES=[0, 3, 4, 5],  # 0 is height, 1 is weight, 2 is muac, 3 is age, 4 is sex('male' or 'female'), 5 is quality ('good' or 'bad'), 6 is test
+    TARGET_INDEXES=[1, 3, 4, 5],  # 0 is height, 1 is weight, 2 is muac, 3 is age, 4 is sex('male' or 'female'), 5 is quality ('good' or 'bad'), 6 is test
     CODES=['100', '101', '102', '200', '201', '202']
 ))
 
-# Result configuration for result generation after evaluation is done
+
+#Result configuration for result generation after evaluation is done
 RESULT_CONFIG = Bunch(dict(
     # Error margin on various ranges
     ACCURACIES=[.2, .4, .6, 1., 1.2, 2., 2.5, 3., 4., 5., 6.],  # 0.2cm, 0.4cm, 0.6cm, 1cm, ...
-    ACCURACY_MAIN_HEIGHT_THRESH=1.0,  # 1cm
+    ACCURACY_MAIN_WEIGHT_THRESH=210,  # 210gms
     AGE_BUCKETS=[0, 1, 2, 3, 4, 5],
 
     COLUMNS=['qrcode', 'artifact', 'scantype', 'GT', 'predicted'],

--- a/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_weight_dropout.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_weight_dropout.py
@@ -44,8 +44,8 @@ DATA_CONFIG = Bunch(dict(
 #Result configuration for result generation after evaluation is done
 RESULT_CONFIG = Bunch(dict(
     # Error margin on various ranges
-    ACCURACIES=[0.04, 0.1, 0.21, 0.42],  # 0.2cm, 0.4cm, 0.6cm, 1cm, ...
-    ACCURACY_MAIN_THRESH=210,  # 210gms
+    ACCURACIES=[0.04, 0.1, 0.21, 0.42],  # 40gms, 100gms, 210gms, 420gms
+    ACCURACY_MAIN_THRESH=0.21,  # 210gms
     AGE_BUCKETS=[0, 1, 2, 3, 4, 5],
 
     COLUMNS=['qrcode', 'artifact', 'scantype', 'GT', 'predicted'],

--- a/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_weight_no_dropout.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_weight_no_dropout.py
@@ -2,8 +2,8 @@ from bunch import Bunch
 
 # Details of model used for evaluation
 MODEL_CONFIG = Bunch(dict(
-    EXPERIMENT_NAME='q4-depthmap-plaincnn-weight-95k', # TODO
-    RUN_ID='q4-depthmap-plaincnn-weight-95k_1605774694_c216f6c5',
+    EXPERIMENT_NAME='q4-depthmap-plaincnn-weight-95k',
+    RUN_ID='q4-depthmap-plaincnn-weight-95k_1611336384_5d22b7c1',
     INPUT_LOCATION='outputs',
     NAME='best_model.ckpt',
 ))
@@ -11,7 +11,7 @@ MODEL_CONFIG = Bunch(dict(
 
 EVAL_CONFIG = Bunch(dict(
     # Name of evaluation
-    NAME='q4-depthmap-plaincnn-weight-95k-run_12',  # TODO
+    NAME='q4-depthmap-plaincnn-weight-95k-run_1',
 
     # Experiment in Azure ML which will be used for evaluation
     EXPERIMENT_NAME="QA-pipeline",
@@ -45,8 +45,13 @@ DATA_CONFIG = Bunch(dict(
 RESULT_CONFIG = Bunch(dict(
     # Error margin on various ranges
     ACCURACIES=[0.04, 0.1, 0.21, 0.42],  # 40 gms, 100 gms, 210 gms, 420 gms
+    ACCURACY_MAIN_WEIGHT_THRESH=210,  # 210gms
+    AGE_BUCKETS=[0, 1, 2, 3, 4, 5],
 
     COLUMNS=['qrcode', 'artifact', 'scantype', 'GT', 'predicted'],
+
+    # uncertainty
+    USE_UNCERTAINTY=False,  # Flag to enable model uncertainty calculation
 
     # path of csv file in the experiment which final result is stored
     SAVE_PATH='./outputs/result.csv',

--- a/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_weight_no_dropout.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_weight_no_dropout.py
@@ -45,7 +45,7 @@ DATA_CONFIG = Bunch(dict(
 RESULT_CONFIG = Bunch(dict(
     # Error margin on various ranges
     ACCURACIES=[0.04, 0.1, 0.21, 0.42],  # 40 gms, 100 gms, 210 gms, 420 gms
-    ACCURACY_MAIN_WEIGHT_THRESH=210,  # 210gms
+    ACCURACY_MAIN_THRESH=210,  # 210gms
     AGE_BUCKETS=[0, 1, 2, 3, 4, 5],
 
     COLUMNS=['qrcode', 'artifact', 'scantype', 'GT', 'predicted'],

--- a/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_weight_no_dropout.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_weight_no_dropout.py
@@ -44,8 +44,8 @@ DATA_CONFIG = Bunch(dict(
 # Result configuration for result generation after evaluation is done
 RESULT_CONFIG = Bunch(dict(
     # Error margin on various ranges
-    ACCURACIES=[0.04, 0.1, 0.21, 0.42],  # 40 gms, 100 gms, 210 gms, 420 gms
-    ACCURACY_MAIN_THRESH=210,  # 210gms
+    ACCURACIES=[0.04, 0.1, 0.21, 0.42],  # 40gms, 100gms, 210gms, 420gms
+    ACCURACY_MAIN_THRESH=0.21,  # 210gms
     AGE_BUCKETS=[0, 1, 2, 3, 4, 5],
 
     COLUMNS=['qrcode', 'artifact', 'scantype', 'GT', 'predicted'],

--- a/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_weight_no_dropout.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_weight_no_dropout.py
@@ -28,15 +28,15 @@ EVAL_CONFIG = Bunch(dict(
 
 #Details of Evaluation Dataset
 DATA_CONFIG = Bunch(dict(
-    NAME='anon-depthmap-testset',  # Name of evaluation dataset
+    NAME='anon-realtime-testdata',  # Name of evaluation dataset
 
     IMAGE_TARGET_HEIGHT=240,
     IMAGE_TARGET_WIDTH=180,
 
-    BATCH_SIZE=256,  # Batch size for evaluation
+    BATCH_SIZE=512,  # Batch size for evaluation
     NORMALIZATION_VALUE=7.5,
 
-    TARGET_INDEXES=[1],  # 0 is height, 1 is weight.
+    TARGET_INDEXES=[1, 3, 4, 5],  # 0 is height, 1 is weight.
     CODES=['100', '101', '102', '200', '201', '202']
 ))
 
@@ -54,5 +54,5 @@ RESULT_CONFIG = Bunch(dict(
     USE_UNCERTAINTY=False,  # Flag to enable model uncertainty calculation
 
     # path of csv file in the experiment which final result is stored
-    SAVE_PATH='./outputs/result.csv',
+    SAVE_PATH='./outputs/height',
 ))

--- a/src/common/evaluation/QA/eval_depthmap_models/src/utils.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/utils.py
@@ -184,7 +184,7 @@ def calculate_and_save_results(df_grouped: pd.DataFrame, complete_name: str, csv
 def calculate_performance_sex(code: str, df_mae: pd.DataFrame, result_config: Bunch) -> pd.DataFrame:
     df_mae_filtered = df_mae.iloc[df_mae.index.get_level_values('scantype') == code]
     accuracy_list = []
-    accuracy_thresh = result_config.ACCURACY_MAIN_HEIGHT_THRESH
+    accuracy_thresh = result_config.ACCURACY_MAIN_THRESH
     for _, sex_id in SEX_DICT.items():
         selection = (df_mae_filtered[COLUMN_NAME_SEX] == sex_id)
         df = df_mae_filtered[selection]
@@ -205,7 +205,7 @@ def calculate_performance_sex(code: str, df_mae: pd.DataFrame, result_config: Bu
 def calculate_performance_goodbad(code: str, df_mae: pd.DataFrame, result_config: Bunch) -> pd.DataFrame:
     df_mae_filtered = df_mae.iloc[df_mae.index.get_level_values('scantype') == code]
     accuracy_list = []
-    accuracy_thresh = result_config.ACCURACY_MAIN_HEIGHT_THRESH
+    accuracy_thresh = result_config.ACCURACY_MAIN_THRESH
     for _, goodbad_id in GOODBAD_DICT.items():
         selection = (df_mae_filtered[COLUMN_NAME_GOODBAD] == goodbad_id)
         df = df_mae_filtered[selection]
@@ -226,7 +226,7 @@ def calculate_performance_goodbad(code: str, df_mae: pd.DataFrame, result_config
 def calculate_performance_age(code: str, df_mae: pd.DataFrame, result_config: Bunch) -> pd.DataFrame:
     df_mae_filtered = df_mae.iloc[df_mae.index.get_level_values('scantype') == code]
     accuracy_list = []
-    accuracy_thresh = result_config.ACCURACY_MAIN_HEIGHT_THRESH
+    accuracy_thresh = result_config.ACCURACY_MAIN_THRESH
     age_thresholds = result_config.AGE_BUCKETS
     age_buckets = list(zip(age_thresholds[:-1], age_thresholds[1:]))
     for age_min_years, age_max_years in age_buckets:


### PR DESCRIPTION
**User story:** https://dev.azure.com/cgmorg/ChildGrowthMonitor/_workitems/edit/812

**Changes:**
- ran existing weight experiment `q4-depthmap-plaincnn-weight-95k` in new tenant
- update eval pipeline to track new experiment/run/name

**Before(old tenant):**
![image](https://user-images.githubusercontent.com/1809832/105677833-a9dc1e00-5eec-11eb-8bd7-0f2e79f12712.png)

**Now([new tenant](https://ml.azure.com/experiments/id/5f0723c5-648a-47f7-ab72-b3c0afccaeb2?wsid=/subscriptions/9b5bbfae-d5d1-4aae-a2ca-75159c0c887d/resourcegroups/cgm-ml-prod-we-rg/workspaces/cgm-ml-prod-we-azml&tid=3a27c573-ec1a-4734-9cd3-3208af51794b))**
![image](https://user-images.githubusercontent.com/1809832/106285851-4122d780-6245-11eb-940c-f04d881030c7.png)
