### PR TITLE
Put weight into different output dir

### DIFF
--- a/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_filter.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_filter.py
@@ -1,4 +1,8 @@
+import os
+
 from bunch import Bunch
+
+CONFIG_NAME = os.path.splitext(os.path.basename(__file__))[0]
 
 # Details of model used for evaluation
 MODEL_CONFIG = Bunch(dict(
@@ -69,5 +73,5 @@ RESULT_CONFIG = Bunch(dict(
     DROPOUT_STRENGTH=1,  # 1.0 means like original model
 
     # path of csv file in the experiment which final result is stored
-    SAVE_PATH='./outputs/height',
+    SAVE_PATH=f'./outputs/{CONFIG_NAME}',
 ))

--- a/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_height.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_height.py
@@ -1,4 +1,8 @@
+import os
+
 from bunch import Bunch
+
+CONFIG_NAME = os.path.splitext(os.path.basename(__file__))[0]
 
 # Details of model used for evaluation
 MODEL_CONFIG = Bunch(dict(
@@ -50,5 +54,5 @@ RESULT_CONFIG = Bunch(dict(
     COLUMNS=['qrcode', 'artifact', 'scantype', 'GT', 'predicted'],
 
     # path of csv file in the experiment which final result is stored
-    SAVE_PATH='./outputs/result.csv',
+    SAVE_PATH=f'./outputs/{CONFIG_NAME}',
 ))

--- a/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_height_dropout.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_height_dropout.py
@@ -1,4 +1,8 @@
+import os
+
 from bunch import Bunch
+
+CONFIG_NAME = os.path.splitext(os.path.basename(__file__))[0]
 
 # Details of model used for evaluation
 MODEL_CONFIG = Bunch(dict(
@@ -57,5 +61,5 @@ RESULT_CONFIG = Bunch(dict(
     UNCERTAINTY_THRESHOLD_IN_CM=4.,
 
     # path of csv file in the experiment which final result is stored
-    SAVE_PATH='./outputs/height',
+    SAVE_PATH=f'./outputs/{CONFIG_NAME}',
 ))

--- a/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_height_no_dropout.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_height_no_dropout.py
@@ -1,4 +1,8 @@
+import os
+
 from bunch import Bunch
+
+CONFIG_NAME = os.path.splitext(os.path.basename(__file__))[0]
 
 # Details of model used for evaluation
 MODEL_CONFIG = Bunch(dict(
@@ -53,5 +57,5 @@ RESULT_CONFIG = Bunch(dict(
     USE_UNCERTAINTY=False,  # Flag to enable model uncertainty calculation
 
     # path of csv file in the experiment which final result is stored
-    SAVE_PATH='./outputs/height',
+    SAVE_PATH=f'./outputs/{CONFIG_NAME}',
 ))

--- a/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_weight_dropout.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_weight_dropout.py
@@ -54,5 +54,5 @@ RESULT_CONFIG = Bunch(dict(
     USE_UNCERTAINTY=False,  # Flag to enable model uncertainty calculation
 
     # path of csv file in the experiment which final result is stored
-    SAVE_PATH='./outputs/height',
+    SAVE_PATH='./outputs/weight',
 ))

--- a/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_weight_dropout.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_weight_dropout.py
@@ -1,4 +1,8 @@
+import os
+
 from bunch import Bunch
+
+CONFIG_NAME = os.path.splitext(os.path.basename(__file__))[0]
 
 # Details of model used for evaluation
 MODEL_CONFIG = Bunch(dict(
@@ -54,5 +58,5 @@ RESULT_CONFIG = Bunch(dict(
     USE_UNCERTAINTY=False,  # Flag to enable model uncertainty calculation
 
     # path of csv file in the experiment which final result is stored
-    SAVE_PATH='./outputs/weight',
+    SAVE_PATH=f'./outputs/{CONFIG_NAME}',
 ))

--- a/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_weight_no_dropout.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_weight_no_dropout.py
@@ -54,5 +54,5 @@ RESULT_CONFIG = Bunch(dict(
     USE_UNCERTAINTY=False,  # Flag to enable model uncertainty calculation
 
     # path of csv file in the experiment which final result is stored
-    SAVE_PATH='./outputs/height',
+    SAVE_PATH='./outputs/weight',
 ))

--- a/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_weight_no_dropout.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/qa_config_weight_no_dropout.py
@@ -1,4 +1,8 @@
+import os
+
 from bunch import Bunch
+
+CONFIG_NAME = os.path.splitext(os.path.basename(__file__))[0]
 
 # Details of model used for evaluation
 MODEL_CONFIG = Bunch(dict(
@@ -54,5 +58,5 @@ RESULT_CONFIG = Bunch(dict(
     USE_UNCERTAINTY=False,  # Flag to enable model uncertainty calculation
 
     # path of csv file in the experiment which final result is stored
-    SAVE_PATH='./outputs/weight',
+    SAVE_PATH=f'./outputs/{CONFIG_NAME}',
 ))

--- a/src/common/evaluation/QA/test-pipeline.yml
+++ b/src/common/evaluation/QA/test-pipeline.yml
@@ -74,8 +74,8 @@ jobs:
         src/common/evaluation/QA/eval_depthmap_models/depthmap-*_output.html
         src/common/evaluation/QA/eval_depthmap_models/*.csv
         src/common/evaluation/QA/eval_depthmap_models/*.png
-        src/common/evaluation/QA/eval_depthmap_models/outputs/height/*.csv
-        src/common/evaluation/QA/eval_depthmap_models/outputs/height/*.png
+        src/common/evaluation/QA/eval_depthmap_models/outputs/*/*.csv
+        src/common/evaluation/QA/eval_depthmap_models/outputs/*/*.png
         src/common/evaluation/QA/eval-standardisation-test/standardisation-test_output.html
         src/common/evaluation/QA/eval-standardisation-test/*.csv
         src/common/evaluation/QA/eval-standardisation-test/*.png


### PR DESCRIPTION
**Motivation:** It is hard to keep the overview with so many output assets in the evaluation pipeline runs.

**Solution:** Split the results in several output directories so we can keep the overview, one directory per config we run

Note: This separates weight results from height results