### PR TITLE
Speed up the confusion matrix in model evaluation pipeline

### DIFF
--- a/src/common/evaluation/QA/eval_depthmap_models/src/evaluate.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/evaluate.py
@@ -304,8 +304,11 @@ if __name__ == "__main__":
 
     if HEIGHT_IDX in DATA_CONFIG.TARGET_INDEXES:
         png_file = f"{OUTPUT_CSV_PATH}/stunting_diagnosis_{RUN_ID}.png"
-        print(f"Calculate and save confusion matrix results to {png_file}")
+        print(f"Calculate zscores and save confusion matrix results to {png_file}")
+        start = time.time()
         draw_stunting_diagnosis(df, png_file)
+        end = time.time()
+        print(f"Total time for Calculate zscores and save confusion matrix: {end - start:.3} sec")
 
     if SEX_IDX in DATA_CONFIG.TARGET_INDEXES:
         csv_file = f"{OUTPUT_CSV_PATH}/sex_evaluation_{RUN_ID}.csv"

--- a/src/common/evaluation/QA/eval_depthmap_models/src/evaluate.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/evaluate.py
@@ -18,11 +18,11 @@ from tensorflow.python import keras
 
 import utils
 from constants import DATA_DIR_ONLINE_RUN, DEFAULT_CONFIG, REPO_DIR
-from utils import (AGE_IDX, COLUMN_NAME_AGE, COLUMN_NAME_GOODBAD,
+from utils import (AGE_IDX, COLUMN_NAME_AGE, COLUMN_NAME_GOODBAD, HEIGHT_IDX,
                    COLUMN_NAME_SEX, GOODBAD_IDX, GOODBAD_DICT, SEX_IDX,
                    calculate_performance, calculate_performance_age,
                    calculate_performance_goodbad, calculate_performance_sex,
-                   download_dataset, draw_age_scatterplot,
+                   download_dataset, draw_age_scatterplot, draw_stunting_diagnosis,
                    draw_uncertainty_goodbad_plot, get_dataset_path,
                    get_model_path, draw_uncertainty_scatterplot)
 
@@ -302,10 +302,10 @@ if __name__ == "__main__":
         print(f"Calculate and save scatterplot results to {png_file}")
         draw_age_scatterplot(df, png_file)
 
-    # if HEIGHT_IDX in DATA_CONFIG.TARGET_INDEXES:
-    #     png_file = f"{OUTPUT_CSV_PATH}/stunting_diagnosis_{RUN_ID}.png"
-    #     print(f"Calculate and save confusion matrix results to {png_file}")
-    #     draw_stunting_diagnosis(df, png_file)
+    if HEIGHT_IDX in DATA_CONFIG.TARGET_INDEXES:
+        png_file = f"{OUTPUT_CSV_PATH}/stunting_diagnosis_{RUN_ID}.png"
+        print(f"Calculate and save confusion matrix results to {png_file}")
+        draw_stunting_diagnosis(df, png_file)
 
     if SEX_IDX in DATA_CONFIG.TARGET_INDEXES:
         csv_file = f"{OUTPUT_CSV_PATH}/sex_evaluation_{RUN_ID}.csv"

--- a/src/common/evaluation/QA/eval_depthmap_models/src/utils.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/utils.py
@@ -1,8 +1,6 @@
 from multiprocessing import Pool
 import datetime
-import json
 import os
-import time
 import pickle
 from pathlib import Path
 from typing import Callable, List
@@ -340,8 +338,10 @@ def draw_stunting_diagnosis(df: pd.DataFrame, png_out_fpath: str):
         png_out_fpath: File path where plot image will be saved
     """
     df = parallelize_dataframe(df, calculate_confusion_matrix_stunting)
-    actual = np.where(df['Z_actual'].values<-3,'Severly Stunted',np.where(df['Z_actual'].values>-2,'Not Stunted','Moderately Stunted'))
-    predicted = np.where(df['Z_predicted'].values<-3,'Severly Stunted',np.where(df['Z_predicted'].values>-2,'Not Stunted','Moderately Stunted'))
+    actual = np.where(df['Z_actual'].values < -3, 'Severly Stunted',
+                      np.where(df['Z_actual'].values > -2, 'Not Stunted', 'Moderately Stunted'))
+    predicted = np.where(df['Z_predicted'].values < -3, 'Severly Stunted',
+                         np.where(df['Z_predicted'].values > -2, 'Not Stunted', 'Moderately Stunted'))
     data = confusion_matrix(actual, predicted)
     T, FP, FN = calculate_percentage_confusion_matrix(data)
     fig = plt.figure(figsize=(15, 15))
@@ -358,7 +358,7 @@ def draw_stunting_diagnosis(df: pd.DataFrame, png_out_fpath: str):
 
 def calculate_confusion_matrix_stunting(df):
     cal = Calculator()
-    
+
     def utils(age_in_days, height, sex):
         if MIN_HEIGHT < height <= MAX_HEIGHT and age_in_days <= MAX_AGE:
             return cal.zScore_lhfa(age_in_days=age_in_days, sex=sex, height=height)


### PR DESCRIPTION
# Description

Speed the Model evaluation pipeline
1. Multiprocessing
2. Using apply in place of the loop
3. Using different function(zscore_lhfa)
4. Loading the data for zscore once 

[Bug-](https://dev.azure.com/cgmorg/ChildGrowthMonitor/_workitems/edit/863)

Tested locally:
For 20 QR code
Before suggested change:- 43 sec
After suggested change:- 9 sec
After removing multiprocessing:- 20 sec.



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests
- [ ] New and existing unit tests pass locally with my changes
- [ ] My Code is review by 1 People
