### PR TITLE
Fix flake8 / github actions cache

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -16,16 +16,16 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/cache@v2
-      id: cache-venv
-      with:
-        path: ./.venv/
-        key: ${{ runner.os }}-venv-${{ hashFiles('requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-venv-
+    # - uses: actions/cache@v2
+    #   id: cache-venv
+    #   with:
+    #     path: ./.venv/
+    #     key: ${{ runner.os }}-venv-${{ hashFiles('requirements.txt') }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-venv-
     - run: python -m venv ./.venv && . ./.venv/bin/activate &&
            python -m pip install --upgrade pip && pip install setuptools==50.3.2 wheel==0.36.2 && pip install -r requirements.txt
-      if: steps.cache-venv.outputs.cache-hit != 'true'
+      # if: steps.cache-venv.outputs.cache-hit != 'true'
     - name: flake8
       run: |
         . ./.venv/bin/activate && flake8 src/

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -16,16 +16,16 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    # - uses: actions/cache@v2
-    #   id: cache-venv
-    #   with:
-    #     path: ./.venv/
-    #     key: ${{ runner.os }}-venv-${{ hashFiles('requirements.txt') }}
-    #     restore-keys: |
-    #       ${{ runner.os }}-venv-
+    - uses: actions/cache@v2
+      id: cache-venv
+      with:
+        path: ./.venv/
+        key: ${{ runner.os }}-cache-v2-${{ hashFiles('requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-cache-v2-
     - run: python -m venv ./.venv && . ./.venv/bin/activate &&
            python -m pip install --upgrade pip && pip install setuptools==50.3.2 wheel==0.36.2 && pip install -r requirements.txt
-      # if: steps.cache-venv.outputs.cache-hit != 'true'
+      if: steps.cache-venv.outputs.cache-hit != 'true'
     - name: flake8
       run: |
         . ./.venv/bin/activate && flake8 src/


### PR DESCRIPTION
Hotfix

The cache was somehow broken leading to the wrong environment being cached. 
[The cache cannot be cleared](https://stackoverflow.com/questions/63521430/clear-cache-in-github-actions). 

Instead we now version the cache key and will change it whenever this happens again
