### PR TITLE
Fix training download dataset

### DIFF
--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/src/train.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/src/train.py
@@ -74,7 +74,18 @@ else:
         dataset_path = sys.argv[1]  # This expects the dataset_path to be the first argument to this script
     elif CONFIG.DATASET_MODE == DATASET_MODE_DOWNLOAD:
         dataset_path = get_dataset_path(DATA_DIR_ONLINE_RUN, dataset_name)
-        download_dataset(workspace, dataset_name, dataset_path)
+        print("before dataset_path", dataset_path)
+        # download_dataset(workspace, dataset_name, dataset_path)
+
+        # The download location can be retrieved from argument values
+        download_location = sys.argv[1]
+        print("download_location", download_location)
+        # The download location can also be retrieved from input_datasets of the run context.
+        download_location = run.input_datasets['input_1']
+        print("download_location", download_location)
+
+        dataset_path = download_location
+
     else:
         raise NameError(f"Unknown DATASET_MODE: {CONFIG.DATASET_MODE}")
 

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/src/train.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/src/train.py
@@ -70,24 +70,7 @@ else:
     dataset_name = CONFIG.DATASET_NAME
 
     # Mount or download
-    if CONFIG.DATASET_MODE == DATASET_MODE_MOUNT:
-        dataset_path = sys.argv[1]  # This expects the dataset_path to be the first argument to this script
-    elif CONFIG.DATASET_MODE == DATASET_MODE_DOWNLOAD:
-        dataset_path = get_dataset_path(DATA_DIR_ONLINE_RUN, dataset_name)
-        print("before dataset_path", dataset_path)
-        # download_dataset(workspace, dataset_name, dataset_path)
-
-        # The download location can be retrieved from argument values
-        download_location = sys.argv[1]
-        print("download_location", download_location)
-        # The download location can also be retrieved from input_datasets of the run context.
-        download_location = run.input_datasets['input_1']
-        print("download_location", download_location)
-
-        dataset_path = download_location
-
-    else:
-        raise NameError(f"Unknown DATASET_MODE: {CONFIG.DATASET_MODE}")
+    dataset_path = run.input_datasets['input_1']
 
 # Get the QR-code paths.
 dataset_path = os.path.join(dataset_path, "scans")

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/src/train.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/src/train.py
@@ -68,7 +68,7 @@ else:
     dataset_name = CONFIG.DATASET_NAME
 
     # Mount or download
-    dataset_path = run.input_datasets['input_1']
+    dataset_path = run.input_datasets['cgm_dataset']
 
 # Get the QR-code paths.
 dataset_path = os.path.join(dataset_path, "scans")

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/src/train.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/src/train.py
@@ -3,7 +3,6 @@ import os
 import pickle
 import random
 import shutil
-import sys
 import logging
 import logging.config
 
@@ -14,9 +13,8 @@ from azureml.core.run import Run
 import wandb
 from wandb.keras import WandbCallback
 
-
-from config import CONFIG, DATASET_MODE_DOWNLOAD, DATASET_MODE_MOUNT
-from constants import DATA_DIR_ONLINE_RUN, MODEL_CKPT_FILENAME, REPO_DIR
+from config import CONFIG
+from constants import MODEL_CKPT_FILENAME, REPO_DIR
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s - %(pathname)s: line %(lineno)d')
 

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/train_notebook.ipynb
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/train_notebook.ipynb
@@ -279,7 +279,7 @@
    "outputs": [],
    "source": [
     "if CONFIG.DATASET_MODE == DATASET_MODE_MOUNT:\n",
-    "    dataset_argument = dataset.as_mount()\n",
+    "    dataset_argument = dataset.as_named_input('input_1').as_mount()\n",
     "elif CONFIG.DATASET_MODE == DATASET_MODE_DOWNLOAD:\n",
     "    dataset_argument = dataset.as_named_input('input_1').as_download()\n",
     "else:\n",
@@ -296,7 +296,7 @@
     "script_run_config = ScriptRunConfig(source_directory=temp_path,\n",
     "                                    compute_target=compute_target,\n",
     "                                    script='train.py',\n",
-    "                                    arguments=[dataset_argument]+[str(item) for sublist in script_params.items() for item in sublist],\n",
+    "                                    arguments=[dataset_argument] + [str(item) for sublist in script_params.items() for item in sublist],\n",
     "                                    environment=cgm_env,\n",
     ")\n",
     "\n",

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/train_notebook.ipynb
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/train_notebook.ipynb
@@ -281,7 +281,7 @@
     "if CONFIG.DATASET_MODE == DATASET_MODE_MOUNT:\n",
     "    dataset_argument = dataset.as_mount()\n",
     "elif CONFIG.DATASET_MODE == DATASET_MODE_DOWNLOAD:\n",
-    "    dataset_argument = dataset.as_download()\n",
+    "    dataset_argument = dataset.as_named_input('input_1').as_download()\n",
     "else:\n",
     "    raise Exception(\"Please specify DATASET_MODE\")"
    ]

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/train_notebook.ipynb
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/train_notebook.ipynb
@@ -279,9 +279,9 @@
    "outputs": [],
    "source": [
     "if CONFIG.DATASET_MODE == DATASET_MODE_MOUNT:\n",
-    "    dataset_argument = dataset.as_named_input('input_1').as_mount()\n",
+    "    dataset_argument = dataset.as_named_input('cgm_dataset').as_mount()\n",
     "elif CONFIG.DATASET_MODE == DATASET_MODE_DOWNLOAD:\n",
-    "    dataset_argument = dataset.as_named_input('input_1').as_download()\n",
+    "    dataset_argument = dataset.as_named_input('cgm_dataset').as_download()\n",
     "else:\n",
     "    raise Exception(\"Please specify DATASET_MODE\")"
    ]

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/train_notebook.ipynb
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/train_notebook.ipynb
@@ -51,7 +51,7 @@
    "outputs": [],
    "source": [
     "dataset_name = \"anon-depthmap-95k\"  # \"anon-depthmap-mini\"\n",
-    "experiment_name = \"test-py37\"\n",
+    "experiment_name = \"q3-depthmap-plaincnn-height-95k\"\n",
     "tags = {}"
    ]
   },

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/train_notebook.ipynb
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/train_notebook.ipynb
@@ -51,7 +51,7 @@
    "outputs": [],
    "source": [
     "dataset_name = \"anon-depthmap-95k\"  # \"anon-depthmap-mini\"\n",
-    "experiment_name = \"q3-depthmap-plaincnn-height-95k\"\n",
+    "experiment_name = \"test-py37\"\n",
     "tags = {}"
    ]
   },
@@ -248,7 +248,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from src.config import CONFIG, DATASET_MODE_MOUNT\n",
+    "from src.config import CONFIG, DATASET_MODE_MOUNT, DATASET_MODE_DOWNLOAD\n",
     "\n",
     "script_params = {f\"--{k}\": v for k, v in CONFIG.items()}\n",
     "script_params"
@@ -278,11 +278,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "if CONFIG.DATASET_MODE == DATASET_MODE_MOUNT:\n",
+    "    dataset_argument = dataset.as_mount()\n",
+    "elif CONFIG.DATASET_MODE == DATASET_MODE_DOWNLOAD:\n",
+    "    dataset_argument = dataset.as_download()\n",
+    "else:\n",
+    "    raise Exception(\"Please specify DATASET_MODE\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Create the ScriptRunConfig\n",
     "script_run_config = ScriptRunConfig(source_directory=temp_path,\n",
     "                                    compute_target=compute_target,\n",
     "                                    script='train.py',\n",
-    "                                    arguments=[dataset.as_mount()]+[str(item) for sublist in script_params.items() for item in sublist],\n",
+    "                                    arguments=[dataset_argument]+[str(item) for sublist in script_params.items() for item in sublist],\n",
     "                                    environment=cgm_env,\n",
     ")\n",
     "\n",

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/train.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/train.py
@@ -9,8 +9,8 @@ from azureml.core import Experiment, Workspace
 from azureml.core.run import Run
 from tensorflow.keras import callbacks, layers, models
 
-from config import CONFIG, DATASET_MODE_DOWNLOAD, DATASET_MODE_MOUNT
-from constants import DATA_DIR_ONLINE_RUN, MODEL_CKPT_FILENAME, REPO_DIR
+from config import CONFIG
+from constants import MODEL_CKPT_FILENAME, REPO_DIR
 from augmentation import tf_augment_sample
 from preprocessing_multiartifact import tf_load_pickle
 
@@ -64,13 +64,7 @@ else:
     dataset_name = CONFIG.DATASET_NAME
 
     # Mount or download
-    if CONFIG.DATASET_MODE == DATASET_MODE_MOUNT:
-        dataset_path = run.input_datasets["dataset"]
-    elif CONFIG.DATASET_MODE == DATASET_MODE_DOWNLOAD:
-        dataset_path = get_dataset_path(DATA_DIR_ONLINE_RUN, dataset_name)
-        download_dataset(workspace, dataset_name, dataset_path)
-    else:
-        raise NameError(f"Unknown DATASET_MODE: {CONFIG.DATASET_MODE}")
+    dataset_path = run.input_datasets['cgm_dataset']
 
 # Get the QR-code paths.
 dataset_scans_path = os.path.join(dataset_path, "scans")

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/train_notebook.ipynb
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/train_notebook.ipynb
@@ -249,7 +249,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from src.config import CONFIG, DATASET_MODE_MOUNT\n",
+    "from src.config import CONFIG, DATASET_MODE_MOUNT, DATASET_MODE_DOWNLOAD\n",
     "\n",
     "script_params = {f\"--{k}\": v for k, v in CONFIG.items()}\n",
     "script_params"
@@ -276,6 +276,20 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if CONFIG.DATASET_MODE == DATASET_MODE_MOUNT:\n",
+    "    dataset_argument = dataset.as_named_input('cgm_dataset').as_mount()\n",
+    "elif CONFIG.DATASET_MODE == DATASET_MODE_DOWNLOAD:\n",
+    "    dataset_argument = dataset.as_named_input('cgm_dataset').as_download()\n",
+    "else:\n",
+    "    raise Exception(\"Please specify DATASET_MODE\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
@@ -285,7 +299,7 @@
     "script_run_config = ScriptRunConfig(source_directory=temp_path,\n",
     "                                    compute_target=compute_target,\n",
     "                                    script='train.py',\n",
-    "                                    arguments=[dataset.as_mount()]+[str(item) for sublist in script_params.items() for item in sublist],\n",
+    "                                    arguments=[dataset_argument] + [str(item) for sublist in script_params.items() for item in sublist],\n",
     "                                    environment=cgm_env,\n",
     ")\n",
     "\n",

--- a/src/models/CNNDepthMap/CNNDepthMap-multitask/q4-depthmap-plaincnn-multitask/src/train.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-multitask/q4-depthmap-plaincnn-multitask/src/train.py
@@ -3,7 +3,6 @@ import os
 import pickle
 import random
 import shutil
-import sys
 
 import glob2 as glob
 import tensorflow as tf
@@ -11,8 +10,8 @@ from tensorflow.keras import layers, Model
 from azureml.core import Experiment, Workspace
 from azureml.core.run import Run
 
-from config import CONFIG, DATASET_MODE_DOWNLOAD, DATASET_MODE_MOUNT
-from constants import DATA_DIR_ONLINE_RUN, MODEL_CKPT_FILENAME, REPO_DIR
+from config import CONFIG
+from constants import MODEL_CKPT_FILENAME, REPO_DIR
 
 # Get the current run.
 run = Run.get_context()
@@ -63,13 +62,7 @@ else:
     dataset_name = CONFIG.DATASET_NAME
 
     # Mount or download
-    if CONFIG.DATASET_MODE == DATASET_MODE_MOUNT:
-        dataset_path = sys.argv[1]  # This expects the dataset_path to be the first argument to this script
-    elif CONFIG.DATASET_MODE == DATASET_MODE_DOWNLOAD:
-        dataset_path = get_dataset_path(DATA_DIR_ONLINE_RUN, dataset_name)
-        download_dataset(workspace, dataset_name, dataset_path)
-    else:
-        raise NameError(f"Unknown DATASET_MODE: {CONFIG.DATASET_MODE}")
+    dataset_path = run.input_datasets['cgm_dataset']
 
 # Get the QR-code paths.
 dataset_path = os.path.join(dataset_path, "scans")

--- a/src/models/CNNDepthMap/CNNDepthMap-multitask/q4-depthmap-plaincnn-multitask/train_notebook.ipynb
+++ b/src/models/CNNDepthMap/CNNDepthMap-multitask/q4-depthmap-plaincnn-multitask/train_notebook.ipynb
@@ -248,7 +248,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from src.config import CONFIG, DATASET_MODE_MOUNT\n",
+    "from src.config import CONFIG, DATASET_MODE_MOUNT, DATASET_MODE_DOWNLOAD\n",
     "\n",
     "script_params = {f\"--{k}\": v for k, v in CONFIG.items()}\n",
     "script_params"
@@ -275,6 +275,20 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if CONFIG.DATASET_MODE == DATASET_MODE_MOUNT:\n",
+    "    dataset_argument = dataset.as_named_input('cgm_dataset').as_mount()\n",
+    "elif CONFIG.DATASET_MODE == DATASET_MODE_DOWNLOAD:\n",
+    "    dataset_argument = dataset.as_named_input('cgm_dataset').as_download()\n",
+    "else:\n",
+    "    raise Exception(\"Please specify DATASET_MODE\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
@@ -284,7 +298,7 @@
     "script_run_config = ScriptRunConfig(source_directory=temp_path,\n",
     "                                    compute_target=compute_target,\n",
     "                                    script='train.py',\n",
-    "                                    arguments=[dataset.as_mount()]+[str(item) for sublist in script_params.items() for item in sublist],\n",
+    "                                    arguments=[dataset_argument] + [str(item) for sublist in script_params.items() for item in sublist],\n",
     "                                    environment=cgm_env,\n",
     ")\n",
     "\n",


### PR DESCRIPTION
**Motivation**: After our update to py3.7, we potentially mounted instead of downloading because we used our own code to download

**Solution**: The [azureml documentation](https://docs.microsoft.com/en-us/python/api/azureml-core/azureml.data.dataset_consumption_config.datasetconsumptionconfig?view=azure-ml-py#methods) tells what to do. We adhere to that.

Done for 3 experiments that we maintain actively:
- `src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/`
- `src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/`
- `src/models/CNNDepthMap/CNNDepthMap-multitask/q4-depthmap-plaincnn-multitask/`