### PR TITLE
Rename ws to workspace to be more consistent

### DIFF
--- a/docs/Onboarding.ipynb
+++ b/docs/Onboarding.ipynb
@@ -44,17 +44,17 @@
    "outputs": [],
    "source": [
     "from azureml.core import Workspace\n",
-    "#ws = Workspace.from_config()\n",
+    "#workspace = Workspace.from_config()\n",
     "\n",
     "#Use the above for Users from the WHH tenant. Following code is only needed to specify the tenant we´re authenticating against.\n",
     "\n",
     "from azureml.core.authentication import InteractiveLoginAuthentication\n",
     "\n",
     "interactive_auth = InteractiveLoginAuthentication(tenant_id=\"006dabd7-456d-465b-a87f-f7d557e319c8\")\n",
-    "ws = Workspace(subscription_id=\"9b82ecea-6780-4b85-8acf-d27d79028f07\",\n",
-    "               resource_group=\"cgm-ml-prod\",\n",
-    "               workspace_name=\"cgm-azureml-prod\",\n",
-    "              auth=interactive_auth)\n",
+    "workspace = Workspace(subscription_id=\"9b82ecea-6780-4b85-8acf-d27d79028f07\",\n",
+    "                      resource_group=\"cgm-ml-prod\",\n",
+    "                      workspace_name=\"cgm-azureml-prod\",\n",
+    "                      auth=interactive_auth)\n",
     "              "
    ]
   },
@@ -2552,14 +2552,14 @@
     "cluster_name = \"cpu-cluster\"\n",
     "\n",
     "try:\n",
-    "    compute_target = ComputeTarget(workspace=ws, name=cluster_name)\n",
+    "    compute_target = ComputeTarget(workspace=workspace, name=cluster_name)\n",
     "    print('Found existing compute target')\n",
     "except ComputeTargetException:\n",
     "    print('Creating a new compute target...')\n",
     "    compute_config = AmlCompute.provisioning_configuration(\n",
     "        vm_size='Standard_D2_v2', \n",
     "       max_nodes=1)\n",
-    "    compute_target = ComputeTarget.create(ws, cluster_name, compute_config)\n",
+    "    compute_target = ComputeTarget.create(workspace, cluster_name, compute_config)\n",
     "    compute_target.wait_for_completion(show_output=True, min_node_count=None, timeout_in_minutes=20)\n",
     "    \n",
     "compute_target"
@@ -2600,7 +2600,7 @@
    "source": [
     "from azureml.core import Experiment\n",
     "experiment_name = \"My-first-Experiment\"\n",
-    "experiment = Experiment(workspace=ws, name=experiment_name)\n",
+    "experiment = Experiment(workspace=workspace, name=experiment_name)\n",
     "experiment"
    ]
   },

--- a/experimental/pose_estimation/QA/poseest_notebook.ipynb
+++ b/experimental/pose_estimation/QA/poseest_notebook.ipynb
@@ -256,7 +256,7 @@
         "#When run manually use below\n",
         "workspace = Workspace.from_config()\n",
         "#When run through pipeline use below\n",
-        "#ws = Workspace.from_config(auth = get_auth())"
+        "#workspace = Workspace.from_config(auth = get_auth())"
       ],
       "outputs": [],
       "execution_count": 43,

--- a/experimental/pose_estimation/commonpy.py
+++ b/experimental/pose_estimation/commonpy.py
@@ -7,9 +7,9 @@ from azureml.core import Dataset, Workspace
 
 
 def getMountContext(path):
-    ws = Workspace.from_config()
-    ws
-    dataset = Dataset.get_by_name(ws, name=path)
+    workspace = Workspace.from_config()
+    workspace
+    dataset = Dataset.get_by_name(workspace, name=path)
     type(dataset)
 
     mount_context = dataset.mount()

--- a/old/cgm-dataset/create-dataset/create_dataset.py
+++ b/old/cgm-dataset/create-dataset/create_dataset.py
@@ -40,7 +40,7 @@ target_folder = cfg['paths']['target_path']
 ml_connector = dbutils.connect_to_main_database(db_file)
 columns = ml_connector.get_columns('artifacts_with_target')
 
-#query to select the data from the database. NOTE: storing all the data in dataframe and then filtering is much faster 
+#query to select the data from the database. NOTE: storing all the data in dataframe and then filtering is much faster
 select_artifacts_with_target = "select * from artifacts_with_target;"
 database = ml_connector.execute(select_artifacts_with_target, fetch_all=True)
 complete_data = database[database['tag'] =='good']
@@ -55,7 +55,7 @@ testing_qrcodes = pd.read_csv(training_file)
 testing_qrcodes = testing_qrcodes['qrcode'].tolist()
 used_qrcodes = training_qrcodes+testing_qrcodes
 
-## filter the qrcodes and sleect the potential qrcodes that can be used for creating new dataset 
+## filter the qrcodes and sleect the potential qrcodes that can be used for creating new dataset
 potential_qrcodes = list(set(usable_qrcodes['qrcode'].tolist()) - set(used_qrcodes))
 if len(potential_qrcodes) >= int(number_of_scans):
     selected_qrcodes = random.sample(potential_qrcodes,int(number_of_scans))
@@ -78,8 +78,8 @@ def lenovo_pcd2depth(pcd,calibration):
         y = round(v[1])
         y = round(height - v[1] - 1)
         if x >= 0 and y >= 0 and x < width and y < height:
-            output[x][y] = p[2]        
-    return output 
+            output[x][y] = p[2]
+    return output
 
 #Read the Calibration file and set the required shape fro height and width
 calibration = utils.parseCalibration(calibration_file)
@@ -89,9 +89,9 @@ Height = utils.setHeight(int(180 * 0.75))
 # data = pd.read_csv('new_data.csv')
 data = new_data[['qrcode','storage_path','height','weight','key']].values.tolist()
 
-#Mount all the dataset 
-ws = Workspace.from_config()
-dataset = Dataset.get_by_name(ws, name= dataset_name)
+#Mount all the dataset
+workspace = Workspace.from_config()
+dataset = Dataset.get_by_name(workspace, name= dataset_name)
 mount_context = dataset.mount()
 mount_context.start()  # this will mount the file streams
 print("mounting_point: ", mount_context.mount_point)
@@ -102,7 +102,7 @@ unprocess =[]
 if not os.path.exists(target):
         os.mkdir(target)
 
-## fucntion to process all the pcd files to depthmaps 
+## fucntion to process all the pcd files to depthmaps
 def process_file(pointcloud):
     """
     Process the pointcloud files
@@ -120,7 +120,7 @@ def process_file(pointcloud):
     targetpath =target+scantype+'/'+qrcodefile
     if not os.path.exists(targetpath):
         os.mkdir(targetpath)
-    pickle_file = targetpath+'/'+ point_file 
+    pickle_file = targetpath+'/'+ point_file
     try:
         sample_depthmap = lenovo_pcd2depth(sourcefile,calibration)
     except:
@@ -131,14 +131,14 @@ def process_file(pointcloud):
     data = (sample_depthmap,labels)
     pickle.dump(data, open(pickle_file, "wb"))
     return
-    
+
 proc = multiprocessing.Pool()
 for files in datas:
     # launch a process for each file (ish).
     # The result will be approximately one process per CPU core available.
-    proc.apply_async(process_file, [files]) 
+    proc.apply_async(process_file, [files])
 
 p.close()
 p.join() # Wait for all child processes to close.
-    
+
 mount_context.stop() ## stop the mounting stream

--- a/src/analyses/reliability/Standing-laying/Evaluation_standing_laying.ipynb
+++ b/src/analyses/reliability/Standing-laying/Evaluation_standing_laying.ipynb
@@ -127,12 +127,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ws = Workspace.from_config()\n",
+    "workspace = Workspace.from_config()\n",
     "EXPERIMENT_NAME='q4-rgb-plaincnn-classifaction-standing-lying-8k'\n",
     "RUN_ID='q4-rgb-plaincnn-classifaction-standing-lying-8k_1602316038_3ebdb326'\n",
     "INPUT_LOCATION = 'outputs/best_model.h5'\n",
     "OUTPUT_LOCATION= REPO_DIR / 'src' / 'analyses' / 'reliability' / 'Standing-laying'\n",
-    "download_model(ws, EXPERIMENT_NAME, RUN_ID, INPUT_LOCATION, OUTPUT_LOCATION)"
+    "download_model(workspace, EXPERIMENT_NAME, RUN_ID, INPUT_LOCATION, OUTPUT_LOCATION)"
    ]
   },
   {

--- a/src/analyses/reliability/Standing-laying/utils.py
+++ b/src/analyses/reliability/Standing-laying/utils.py
@@ -78,17 +78,17 @@ def standing_laying_predict(qrcode_pcd_rgb, model):
     return qr_codes_predicts
 
 
-def download_model(ws, experiment_name, run_id, input_location, output_location):
+def download_model(workspace, experiment_name, run_id, input_location, output_location):
     '''
     Download the pretrained model
     Input:
-         ws: workspace to access the experiment
+         workspace: workspace to access the experiment
          experiment_name: Name of the experiment in which model is saved
          run_id: Run Id of the experiment in which model is pre-trained
          input_location: Input location in a RUN Id
          output_location: Location for saving the model
     '''
-    experiment = Experiment(workspace=ws, name=experiment_name)
+    experiment = Experiment(workspace=workspace, name=experiment_name)
     #Download the model on which evaluation need to be done
     run = Run(experiment, run_id=run_id)
     #run.get_details()

--- a/src/common/evaluation/QA/auth.py
+++ b/src/common/evaluation/QA/auth.py
@@ -27,9 +27,9 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     workspace = Workspace(subscription_id=args.subscription_id,
-                   resource_group=args.resource_group,
-                   workspace_name=args.workspace_name,
-                   auth=get_auth())
+                          resource_group=args.resource_group,
+                          workspace_name=args.workspace_name,
+                          auth=get_auth())
 
     logging.info("Workspace Details")
     logging.info(workspace.get_details())

--- a/src/common/evaluation/QA/auth.py
+++ b/src/common/evaluation/QA/auth.py
@@ -26,15 +26,15 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    ws = Workspace(subscription_id=args.subscription_id,
+    workspace = Workspace(subscription_id=args.subscription_id,
                    resource_group=args.resource_group,
                    workspace_name=args.workspace_name,
                    auth=get_auth())
 
     logging.info("Workspace Details")
-    logging.info(ws.get_details())
+    logging.info(workspace.get_details())
 
     logging.info("Success of Authentication and Workspace Setup")
 
-    ws.write_config()
+    workspace.write_config()
     logging.info("Saved config file")

--- a/src/common/evaluation/QA/eval-standardisation-test/auth.py
+++ b/src/common/evaluation/QA/eval-standardisation-test/auth.py
@@ -28,15 +28,15 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    ws = Workspace(subscription_id=args.subscription_id,
+    workspace = Workspace(subscription_id=args.subscription_id,
                    resource_group=args.resource_group,
                    workspace_name=args.workspace_name,
                    auth=get_auth())
 
     logging.info("Workspace Details")
-    logging.info(ws.get_details())
+    logging.info(workspace.get_details())
 
     logging.info("Success of Authentication and Workspace Setup")
 
-    ws.write_config()
+    workspace.write_config()
     logging.info("Saved config file")

--- a/src/common/evaluation/QA/eval-standardisation-test/auth.py
+++ b/src/common/evaluation/QA/eval-standardisation-test/auth.py
@@ -29,9 +29,9 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     workspace = Workspace(subscription_id=args.subscription_id,
-                   resource_group=args.resource_group,
-                   workspace_name=args.workspace_name,
-                   auth=get_auth())
+                          resource_group=args.resource_group,
+                          workspace_name=args.workspace_name,
+                          auth=get_auth())
 
     logging.info("Workspace Details")
     logging.info(workspace.get_details())

--- a/src/common/evaluation/QA/eval-standardisation-test/eval_notebook.ipynb
+++ b/src/common/evaluation/QA/eval-standardisation-test/eval_notebook.ipynb
@@ -92,7 +92,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ws = Workspace.from_config()"
+    "workspace = Workspace.from_config()"
    ]
   },
   {
@@ -101,7 +101,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "download_model(ws=ws,\n",
+    "download_model(workspace,\n",
     "               experiment_name=MODEL_CONFIG.EXPERIMENT_NAME,\n",
     "               run_id=MODEL_CONFIG.RUN_ID,\n",
     "               input_location=os.path.join(MODEL_CONFIG.INPUT_LOCATION, MODEL_CONFIG.NAME),\n",
@@ -114,7 +114,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "experiment = Experiment(workspace = ws, name = EVAL_CONFIG.EXPERIMENT_NAME)"
+    "experiment = Experiment(workspace=workspace, name=EVAL_CONFIG.EXPERIMENT_NAME)"
    ]
   },
   {
@@ -137,7 +137,7 @@
     "\n",
     "# Compute cluster exists. Just connect to it.\n",
     "try:\n",
-    "    compute_target = ComputeTarget(workspace = ws, name = EVAL_CONFIG.CLUSTER_NAME)\n",
+    "    compute_target = ComputeTarget(workspace=workspace, name=EVAL_CONFIG.CLUSTER_NAME)\n",
     "    print(\"Found existing compute target.\")\n",
     "\n",
     "# Compute cluster does not exist. Create one.    \n",
@@ -160,7 +160,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset = ws.datasets[DATA_CONFIG.NAME]\n",
+    "dataset = workspace.datasets[DATA_CONFIG.NAME]\n",
     "dataset"
    ]
   },

--- a/src/common/evaluation/QA/eval-standardisation-test/src/utils.py
+++ b/src/common/evaluation/QA/eval-standardisation-test/src/utils.py
@@ -214,17 +214,17 @@ def setHeight(value):
     height = value
 
 
-def download_model(ws, experiment_name, run_id, input_location, output_location):
+def download_model(workspace, experiment_name, run_id, input_location, output_location):
     '''
     Download the pretrained model
     Input:
-         ws: workspace to access the experiment
+         workspace: workspace to access the experiment
          experiment_name: Name of the experiment in which model is saved
          run_id: Run Id of the experiment in which model is pre-trained
          input_location: Input location in a RUN Id
          output_location: Location for saving the model
     '''
-    experiment = Experiment(workspace=ws, name=experiment_name)
+    experiment = Experiment(workspace=workspace, name=experiment_name)
     #Download the model on which evaluation need to be done
     run = Run(experiment, run_id=run_id)
     #run.get_details()

--- a/src/common/evaluation/QA/eval_depthmap_models/auth.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/auth.py
@@ -28,15 +28,15 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    ws = Workspace(subscription_id=args.subscription_id,
+    workspace = Workspace(subscription_id=args.subscription_id,
                    resource_group=args.resource_group,
                    workspace_name=args.workspace_name,
                    auth=get_auth())
 
     logging.info("Workspace Details")
-    logging.info(ws.get_details())
+    logging.info(workspace.get_details())
 
     logging.info("Success of Authentication and Workspace Setup")
 
-    ws.write_config()
+    workspace.write_config()
     logging.info("Saved config file")

--- a/src/common/evaluation/QA/eval_depthmap_models/auth.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/auth.py
@@ -29,9 +29,9 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     workspace = Workspace(subscription_id=args.subscription_id,
-                   resource_group=args.resource_group,
-                   workspace_name=args.workspace_name,
-                   auth=get_auth())
+                          resource_group=args.resource_group,
+                          workspace_name=args.workspace_name,
+                          auth=get_auth())
 
     logging.info("Workspace Details")
     logging.info(workspace.get_details())

--- a/src/common/evaluation/QA/eval_depthmap_models/eval_main.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/eval_main.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
     for p in utils_paths:
         shutil.copy(p, temp_model_utils_dir)
 
-    ws = Workspace.from_config()
+    workspace = Workspace.from_config()
 
     run = Run.get_context()
 
@@ -71,7 +71,7 @@ if __name__ == "__main__":
     os.makedirs(MODEL_BASE_DIR, exist_ok=True)
 
     # Copy model to temp folder
-    download_model(ws=ws,
+    download_model(workspace,
                    experiment_name=MODEL_CONFIG.EXPERIMENT_NAME,
                    run_id=MODEL_CONFIG.RUN_ID,
                    input_location=os.path.join(MODEL_CONFIG.INPUT_LOCATION, MODEL_CONFIG.NAME),
@@ -79,25 +79,25 @@ if __name__ == "__main__":
 
     # Copy filter to temp folder
     if FILTER_CONFIG is not None and FILTER_CONFIG.IS_ENABLED:
-        download_model(ws=ws, experiment_name=FILTER_CONFIG.EXPERIMENT_NAME, run_id=FILTER_CONFIG.RUN_ID, input_location=os.path.join(
+        download_model(workspace, experiment_name=FILTER_CONFIG.EXPERIMENT_NAME, run_id=FILTER_CONFIG.RUN_ID, input_location=os.path.join(
             FILTER_CONFIG.INPUT_LOCATION, MODEL_CONFIG.NAME), output_location=str(temp_path / FILTER_CONFIG.NAME))
         azureml._restclient.snapshots_client.SNAPSHOT_MAX_SIZE_BYTES = 500000000
 
-    experiment = Experiment(workspace=ws, name=EVAL_CONFIG.EXPERIMENT_NAME)
+    experiment = Experiment(workspace=workspace, name=EVAL_CONFIG.EXPERIMENT_NAME)
 
     # Find/create a compute target.
     try:
         # Compute cluster exists. Just connect to it.
-        compute_target = ComputeTarget(workspace=ws, name=EVAL_CONFIG.CLUSTER_NAME)
+        compute_target = ComputeTarget(workspace=workspace, name=EVAL_CONFIG.CLUSTER_NAME)
         logging.info("Found existing compute target.")
     except ComputeTargetException:
         logging.info("Creating a new compute target...")
         compute_config = AmlCompute.provisioning_configuration(vm_size='Standard_NC6', max_nodes=4)
-        compute_target = ComputeTarget.create(ws, EVAL_CONFIG.CLUSTER_NAME, compute_config)
+        compute_target = ComputeTarget.create(workspace, EVAL_CONFIG.CLUSTER_NAME, compute_config)
         compute_target.wait_for_completion(show_output=True, min_node_count=None, timeout_in_minutes=20)
     logging.info("Compute target: %s", compute_target)
 
-    dataset = ws.datasets[DATA_CONFIG.NAME]
+    dataset = workspace.datasets[DATA_CONFIG.NAME]
     logging.info("dataset: %s", dataset)
     logging.info("TF supported versions: %s", TensorFlow.get_supported_versions())
 

--- a/src/common/evaluation/QA/eval_depthmap_models/src/utils.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/utils.py
@@ -451,17 +451,17 @@ def get_model_path(MODEL_CONFIG: Bunch) -> str:
     raise NameError(f"{MODEL_CONFIG.NAME}'s path extension not supported")
 
 
-def download_model(ws, experiment_name, run_id, input_location, output_location):
+def download_model(workspace, experiment_name, run_id, input_location, output_location):
     """Download the pretrained model
 
     Args:
-         ws: workspace to access the experiment
+         workspace: workspace to access the experiment
          experiment_name: Name of the experiment in which model is saved
          run_id: Run Id of the experiment in which model is pre-trained
          input_location: Input location in a RUN Id
          output_location: Location for saving the model
     """
-    experiment = Experiment(workspace=ws, name=experiment_name)
+    experiment = Experiment(workspace=workspace, name=experiment_name)
     # Download the model on which evaluation need to be done
     run = Run(experiment, run_id=run_id)
     if input_location.endswith(".h5"):

--- a/src/data_utils/data_access_with_labels.ipynb
+++ b/src/data_utils/data_access_with_labels.ipynb
@@ -83,7 +83,7 @@
     "# azureml-core of version 1.0.72 or higher is required\n",
     "from azureml.core import Workspace, Dataset\n",
     "\n",
-    "ws = Workspace.from_config()"
+    "workspace = Workspace.from_config()"
    ]
   },
   {
@@ -99,7 +99,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset = Dataset.get_by_name(ws, name='anon-pcd-version5.0')\n",
+    "dataset = Dataset.get_by_name(workspace, name='anon-pcd-version5.0')\n",
     "type(dataset)"
    ]
   },

--- a/src/data_utils/data_visualisation/data_visualisations.ipynb
+++ b/src/data_utils/data_visualisation/data_visualisations.ipynb
@@ -75,9 +75,9 @@
    },
    "outputs": [],
    "source": [
-    "ws = Workspace.from_config()\n",
-    "ws\n",
-    "dataset = Dataset.get_by_name(ws, name='anon-pcd-7k')\n",
+    "workspace = Workspace.from_config()\n",
+    "workspace\n",
+    "dataset = Dataset.get_by_name(workspace, name='anon-pcd-7k')\n",
     "type(dataset)"
    ]
   },

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/model.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/model.py
@@ -27,7 +27,7 @@ def get_base_model(workspace: Workspace, data_dir: Path) -> models.Sequential:
     return base_model
 
 
-def download_model(ws, experiment_name, run_id, input_location, output_location):
+def download_model(workspace, experiment_name, run_id, input_location, output_location):
     """Download the pretrained model
 
     Args:
@@ -37,7 +37,7 @@ def download_model(ws, experiment_name, run_id, input_location, output_location)
          input_location: Input location in a RUN Id
          output_location: Location for saving the model
     """
-    experiment = Experiment(workspace=ws, name=experiment_name)
+    experiment = Experiment(workspace=workspace, name=experiment_name)
     # Download the model on which evaluation need to be done
     run = Run(experiment, run_id=run_id)
     if input_location.endswith(".h5"):
@@ -52,7 +52,7 @@ def download_model(ws, experiment_name, run_id, input_location, output_location)
 def download_pretrained_model(workspace: Workspace, output_model_fpath: str):
     logging.info('Downloading pretrained model from: %s', CONFIG.PRETRAINED_RUN)
 
-    download_model(ws=workspace,
+    download_model(workspace,
                    experiment_name=CONFIG.PRETRAINED_EXPERIMENT,
                    run_id=CONFIG.PRETRAINED_RUN,
                    input_location=f"outputs/{MODEL_CKPT_FILENAME}",

--- a/src/models/CNNRGB/CNNRGB-standing_laying/q4-rgb-standing-laying/deploy.ipynb
+++ b/src/models/CNNRGB/CNNRGB-standing_laying/q4-rgb-standing-laying/deploy.ipynb
@@ -15,7 +15,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ws = Workspace.from_config()"
+    "workspace = Workspace.from_config()"
    ]
   },
   {
@@ -24,7 +24,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ws"
+    "workspace"
    ]
   },
   {
@@ -50,10 +50,10 @@
    "outputs": [],
    "source": [
     "#skip if model is already registered\n",
-    "model = Model.register(model_path = \"./Standing_laying/\",\n",
-    "                       model_name = \"standing_laying_classifier\",\n",
-    "                       description = \"Standing/laying classifier\",\n",
-    "                       workspace = ws)"
+    "model = Model.register(model_path=\"./Standing_laying/\",\n",
+    "                       model_name=\"standing_laying_classifier\",\n",
+    "                       description=\"Standing/laying classifier\",\n",
+    "                       workspace=workspace)"
    ]
   },
   {
@@ -69,7 +69,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = Model(ws, name='standing_laying_classifier')"
+    "model = Model(workspace, name='standing_laying_classifier')"
    ]
   },
   {
@@ -209,7 +209,7 @@
    "outputs": [],
    "source": [
     "deployment_config = AciWebservice.deploy_configuration(cpu_cores = 2, memory_gb = 4)\n",
-    "service = Model.deploy(ws, \"aci-standing-laying-v\", [model], inference_config_aci, deployment_config)\n",
+    "service = Model.deploy(workspace, \"aci-standing-laying-v\", [model], inference_config_aci, deployment_config)\n",
     "service.wait_for_deployment(show_output = True)\n",
     "print(service.state)"
    ]
@@ -273,9 +273,9 @@
     "                                                       location = \"westeurope\")\n",
     "\n",
     "# Create the cluster\n",
-    "aks_target = ComputeTarget.create(workspace = ws,\n",
-    "                                    name = aks_name,\n",
-    "                                    provisioning_configuration = prov_config)\n",
+    "aks_target = ComputeTarget.create(workspace=workspace,\n",
+    "                                  name=aks_name,\n",
+    "                                  provisioning_configuration=prov_config)\n",
     "\n",
     "# Wait for the create process to complete\n",
     "aks_target.wait_for_completion(show_output = True)"
@@ -330,7 +330,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ws"
+    "workspace"
    ]
   },
   {
@@ -339,10 +339,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "aks_target = AksCompute(ws, \"AKS-interference\")\n",
+    "aks_target = AksCompute(workspace, \"AKS-interference\")\n",
     "\n",
     "deployment_config = AksWebservice.deploy_configuration(cpu_cores = 2, memory_gb = 2, collect_model_data=True, enable_app_insights=True)\n",
-    "service = Model.deploy(ws, \"aks-standing-laying\", [model], inference_config_aks, deployment_config, aks_target)\n",
+    "service = Model.deploy(workspace, \"aks-standing-laying\", [model], inference_config_aks, deployment_config, aks_target)\n",
     "service.wait_for_deployment(show_output = True)\n",
     "print(service.state)"
    ]

--- a/src/models/GAPNet/GAPNet-height/s1-gapnet-height/code/deploy.ipynb
+++ b/src/models/GAPNet/GAPNet-height/s1-gapnet-height/code/deploy.ipynb
@@ -20,7 +20,7 @@
     "resource_group = '.'\n",
     "workspace_name = '.'\n",
     "\n",
-    "ws = Workspace(subscription_id, resource_group, workspace_name)"
+    "workspace = Workspace(subscription_id, resource_group, workspace_name)"
    ]
   },
   {
@@ -40,7 +40,7 @@
     }
    ],
    "source": [
-    "ws"
+    "workspace"
    ]
   },
   {
@@ -74,10 +74,10 @@
    ],
    "source": [
     "#skip if model is already registered\n",
-    "model = Model.register(model_path = \"./GAPNet/\",\n",
-    "                       model_name = \"gapnet_height_s1\",\n",
-    "                       description = \"GAPNet model trained for predicting height\",\n",
-    "                       workspace = ws)"
+    "model = Model.register(model_path=\"./GAPNet/\",\n",
+    "                       model_name=\"gapnet_height_s1\",\n",
+    "                       description=\"GAPNet model trained for predicting height\",\n",
+    "                       workspace=workspace)"
    ]
   },
   {
@@ -93,7 +93,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = Model(ws, name='gapnet_height_s1')"
+    "model = Model(workspace, name='gapnet_height_s1')"
    ]
   },
   {
@@ -281,7 +281,7 @@
    ],
    "source": [
     "deployment_config = AciWebservice.deploy_configuration(cpu_cores = 1, memory_gb = 4)\n",
-    "service = Model.deploy(ws, \"aci-gapnet-height-s1-1\", [model], inference_config_aci, deployment_config)\n",
+    "service = Model.deploy(workspace, \"aci-gapnet-height-s1-1\", [model], inference_config_aci, deployment_config)\n",
     "service.wait_for_deployment(show_output = True)\n",
     "print(service.state)"
    ]
@@ -365,9 +365,9 @@
     "                                                       location = \"westeurope\")\n",
     "\n",
     "# Create the cluster\n",
-    "aks_target = ComputeTarget.create(workspace = ws,\n",
-    "                                    name = aks_name,\n",
-    "                                    provisioning_configuration = prov_config)\n",
+    "aks_target = ComputeTarget.create(workspace=workspace,\n",
+    "                                  name=aks_name,\n",
+    "                                  provisioning_configuration=prov_config)\n",
     "\n",
     "# Wait for the create process to complete\n",
     "aks_target.wait_for_completion(show_output = True)"
@@ -444,7 +444,7 @@
     }
    ],
    "source": [
-    "ws"
+    "workspace"
    ]
   },
   {
@@ -464,10 +464,10 @@
     }
    ],
    "source": [
-    "aks_target = AksCompute(ws, \"GAPNet-height\")\n",
+    "aks_target = AksCompute(workspace, \"GAPNet-height\")\n",
     "\n",
     "deployment_config = AksWebservice.deploy_configuration(cpu_cores = 2, memory_gb = 12, autoscale_enabled=True, autoscale_max_replicas=3, collect_model_data=True, enable_app_insights=True)\n",
-    "service = Model.deploy(ws, \"aks-gapnet-height-s1\", [model], inference_config_aks, deployment_config, aks_target)\n",
+    "service = Model.deploy(workspace, \"aks-gapnet-height-s1\", [model], inference_config_aks, deployment_config, aks_target)\n",
     "service.wait_for_deployment(show_output = True)\n",
     "print(service.state)"
    ]

--- a/src/models/PersonLab/PersonLabV1/code/deploy.ipynb
+++ b/src/models/PersonLab/PersonLabV1/code/deploy.ipynb
@@ -14,7 +14,7 @@
    "outputs": [],
    "source": [
     "from azureml.core import Workspace\n",
-    "ws = Workspace.from_config()"
+    "workspace = Workspace.from_config()"
    ]
   },
   {
@@ -40,10 +40,10 @@
    "outputs": [],
    "source": [
     "#skip if model is already registered\n",
-    "model = Model.register(model_path = \"./personlab/\",\n",
-    "                       model_name = \"personlabV1\",\n",
-    "                       description = \"personalab model for detecting poses\",\n",
-    "                       workspace = ws)"
+    "model = Model.register(model_path=\"./personlab/\",\n",
+    "                       model_name=\"personlabV1\",\n",
+    "                       description=\"personalab model for detecting poses\",\n",
+    "                       workspace=workspace)"
    ]
   },
   {
@@ -59,7 +59,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = Model(ws, name='personlabV1')"
+    "model = Model(workspace, name='personlabV1')"
    ]
   },
   {
@@ -356,7 +356,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "env.register(ws)"
+    "env.register(workspace)"
    ]
   },
   {
@@ -382,7 +382,7 @@
    "outputs": [],
    "source": [
     "deployment_config = AciWebservice.deploy_configuration(cpu_cores = 2, memory_gb = 16,location = \"centralindia\")\n",
-    "service = Model.deploy(ws, \"aci-personlabv1\", [model], inference_config_aci, deployment_config)\n",
+    "service = Model.deploy(workspace, \"aci-personlabv1\", [model], inference_config_aci, deployment_config)\n",
     "service.wait_for_deployment(show_output = True)\n",
     "print(service.state)"
    ]
@@ -444,9 +444,9 @@
     "                                                       location = \"centralindia\")\n",
     "\n",
     "# Create the cluster\n",
-    "aks_target = ComputeTarget.create(workspace = ws,\n",
-    "                                    name = aks_name,\n",
-    "                                    provisioning_configuration = prov_config)\n",
+    "aks_target = ComputeTarget.create(workspace=workspace,\n",
+    "                                  name=aks_name,\n",
+    "                                  provisioning_configuration=prov_config)\n",
     "\n",
     "# Wait for the create process to complete\n",
     "aks_target.wait_for_completion(show_output = True)"
@@ -475,10 +475,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "aks_target = AksCompute(ws,\"webservices\")\n",
+    "aks_target = AksCompute(workspace, \"webservices\")\n",
     "\n",
     "deployment_config = AksWebservice.deploy_configuration(cpu_cores = 6, memory_gb = 64,autoscale_enabled=True, autoscale_max_replicas=3, collect_model_data=True, enable_app_insights=True)\n",
-    "service = Model.deploy(ws, \"aks-personlab-eur-test1\", [model], inference_config_aks, deployment_config,aks_target)\n",
+    "service = Model.deploy(workspace, \"aks-personlab-eur-test1\", [model], inference_config_aks, deployment_config,aks_target)\n",
     "service.wait_for_deployment(show_output = True)\n",
     "print(service.state)"
    ]

--- a/src/models/pointnet/pointnet-height/pointnet-20190708/code/deploy.ipynb
+++ b/src/models/pointnet/pointnet-height/pointnet-20190708/code/deploy.ipynb
@@ -14,7 +14,7 @@
    "outputs": [],
    "source": [
     "from azureml.core import Workspace\n",
-    "ws = Workspace.from_config()"
+    "workspace = Workspace.from_config()"
    ]
   },
   {
@@ -40,10 +40,10 @@
    "outputs": [],
    "source": [
     "#skip if model is already registered\n",
-    "model = Model.register(model_path = \"./pointnet/\",\n",
-    "                       model_name = \"pointnet-height-20190708\",\n",
-    "                       description = \"pointnet model trained for predicting height\",\n",
-    "                       workspace = ws)"
+    "model = Model.register(model_path=\"./pointnet/\",\n",
+    "                       model_name=\"pointnet-height-20190708\",\n",
+    "                       description=\"pointnet model trained for predicting height\",\n",
+    "                       workspace=workspace)"
    ]
   },
   {
@@ -59,7 +59,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = Model(ws, name='pointnet-height-20190708')"
+    "model = Model(workspace, name='pointnet-height-20190708')"
    ]
   },
   {
@@ -205,7 +205,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "env.register(ws)"
+    "env.register(workspace)"
    ]
   },
   {
@@ -231,7 +231,7 @@
    "outputs": [],
    "source": [
     "deployment_config = AciWebservice.deploy_configuration(cpu_cores = 1, memory_gb = 4)\n",
-    "service = Model.deploy(ws, \"aci-pointnet-height-20190708\", [model], inference_config_aci, deployment_config)\n",
+    "service = Model.deploy(workspace, \"aci-pointnet-height-20190708\", [model], inference_config_aci, deployment_config)\n",
     "service.wait_for_deployment(show_output = True)\n",
     "print(service.state)"
    ]
@@ -293,9 +293,9 @@
     "                                                       location = \"westeurope\")\n",
     "\n",
     "# Create the cluster\n",
-    "aks_target = ComputeTarget.create(workspace = ws,\n",
-    "                                    name = aks_name,\n",
-    "                                    provisioning_configuration = prov_config)\n",
+    "aks_target = ComputeTarget.create(workspace=workspace,\n",
+    "                                  name=aks_name,\n",
+    "                                  provisioning_configuration=prov_config)\n",
     "\n",
     "# Wait for the create process to complete\n",
     "aks_target.wait_for_completion(show_output = True)"
@@ -324,10 +324,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "aks_target = AksCompute(ws,\"pointnet-height\")\n",
+    "aks_target = AksCompute(workspace,\"pointnet-height\")\n",
     "\n",
     "deployment_config = AksWebservice.deploy_configuration(cpu_cores = 1, memory_gb = 4)\n",
-    "service = Model.deploy(ws, \"aks-pointnet-height-20190708\", [model], inference_config_aks, deployment_config, aks_target)\n",
+    "service = Model.deploy(workspace, \"aks-pointnet-height-20190708\", [model], inference_config_aks, deployment_config, aks_target)\n",
     "service.wait_for_deployment(show_output = True)\n",
     "print(service.state)"
    ]

--- a/src/models/pointnet/pointnet-height/pointnet-20190806/code/deploy.ipynb
+++ b/src/models/pointnet/pointnet-height/pointnet-20190806/code/deploy.ipynb
@@ -14,7 +14,7 @@
    "outputs": [],
    "source": [
     "from azureml.core import Workspace\n",
-    "ws = Workspace.from_config()"
+    "workspace = Workspace.from_config()"
    ]
   },
   {
@@ -40,10 +40,10 @@
    "outputs": [],
    "source": [
     "#skip if model is already registered\n",
-    "model = Model.register(model_path = \"./pointnet/\",\n",
-    "                       model_name = \"pointnet-height-20190806\",\n",
-    "                       description = \"pointnet model trained for predicting height\",\n",
-    "                       workspace = ws)"
+    "model = Model.register(model_path=\"./pointnet/\",\n",
+    "                       model_name=\"pointnet-height-20190806\",\n",
+    "                       description=\"pointnet model trained for predicting height\",\n",
+    "                       workspace=workspace)"
    ]
   },
   {
@@ -59,7 +59,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = Model(ws, name='pointnet-height-20190806')"
+    "model = Model(workspace, name='pointnet-height-20190806')"
    ]
   },
   {
@@ -205,7 +205,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "env.register(ws)"
+    "env.register(workspace)"
    ]
   },
   {
@@ -231,7 +231,7 @@
    "outputs": [],
    "source": [
     "deployment_config = AciWebservice.deploy_configuration(cpu_cores = 1, memory_gb = 4)\n",
-    "service = Model.deploy(ws, \"aci-pointnet-height-20190806\", [model], inference_config_aci, deployment_config)\n",
+    "service = Model.deploy(workspace, \"aci-pointnet-height-20190806\", [model], inference_config_aci, deployment_config)\n",
     "service.wait_for_deployment(show_output = True)\n",
     "print(service.state)"
    ]
@@ -293,9 +293,9 @@
     "                                                       location = \"westeurope\")\n",
     "\n",
     "# Create the cluster\n",
-    "aks_target = ComputeTarget.create(workspace = ws,\n",
-    "                                    name = aks_name,\n",
-    "                                    provisioning_configuration = prov_config)\n",
+    "aks_target = ComputeTarget.create(workspace=workspace,\n",
+    "                                  name=aks_name,\n",
+    "                                  provisioning_configuration=prov_config)\n",
     "\n",
     "# Wait for the create process to complete\n",
     "aks_target.wait_for_completion(show_output = True)"
@@ -323,10 +323,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "aks_target = AksCompute(ws,\"pointnet-height\")\n",
+    "aks_target = AksCompute(workspace, \"pointnet-height\")\n",
     "\n",
     "deployment_config = AksWebservice.deploy_configuration(cpu_cores = 1, memory_gb = 4)\n",
-    "service = Model.deploy(ws, \"aks-pointnet-height-20190806\", [model], inference_config_aks, deployment_config, aks_target)\n",
+    "service = Model.deploy(workspace, \"aks-pointnet-height-20190806\", [model], inference_config_aks, deployment_config, aks_target)\n",
     "service.wait_for_deployment(show_output = True)\n",
     "print(service.state)"
    ]


### PR DESCRIPTION
**Motivation**: It is confusing to switch between two different names for the same thing

**Solution:** As `workspace` occurs more often in the codebase, we rename `ws` to `workspace` to stick to one consistent way of usage