### PR TITLE
Avoid codecov comment

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false


### PR DESCRIPTION
Example of a comment: 
![image](https://user-images.githubusercontent.com/1809832/111476582-969c4080-872e-11eb-847f-4b3a04a05be5.png)

Motivation: This comment is not super useful, I suggest to keep codecov more quiet and having it too look when we want to see it, but not always