### PR TITLE
Depthmap toolkit visualisation

### DIFF
--- a/src/common/depthmap_toolkit/README.md
+++ b/src/common/depthmap_toolkit/README.md
@@ -30,7 +30,7 @@ In the future we plan to not support PCD files anymore (due to their big size).
 
 ### Visualisation of depthmaps
 
-* The tool accepts only the data captured by cgm-scanner. The data could be captured by any ARCore device supporting ToF sensor. Tool could be opened by following command:
+* The tool accepts only the data captured by cgm-scanner. The data could be captured by any ARCore/AREngine device supporting ToF sensor. Tool could be opened by following command:
 
 `python toolkit.py depthmap_dir`
 
@@ -39,3 +39,12 @@ In the future we plan to not support PCD files anymore (due to their big size).
 * Export OBJ will export the data as a pointcloud into OBJ file in export folder, this data will be reoriented using depthmap pose (if available)
 * Export PCDwill export the data as a pointcloud into PCD file in export folder
 * Convert all PCDs button has the same functionality as convertdepth2pcd
+
+### Visualisation types
+
+The tool generates 5 different visualisations (from left-to-right order):
+* Depth image - this is a most raw visualisation of depthmap
+* World-oriented normals - green value indicates a horizontal surface, blue and red a vertical surface (supported from scan type v1.0)
+* Metrical pattern visualisation - repeating pattern mapped on surfaces based on world-oriented normals, the pattern repeats every 10 centimeters (this might help ML models to calibrate measures captured by different devices, supported from scan type v1.0)
+* Confidence map - amount of IR light reflected into ToF receiver, this information might vary a lot (every sensor uses a different amount of IR light) and it is not recommended to use it for ML training
+* RGB photo - captured photo (if available)

--- a/src/common/depthmap_toolkit/depthmap.py
+++ b/src/common/depthmap_toolkit/depthmap.py
@@ -93,10 +93,10 @@ def show_result():
                 output[x][height - y - 1][:] = 1.0 - min(depth / 2.0, 1.0)
 
                 # depth data normal
-                v = utils.convert_2d_to_3d_oriented(calibration[1], x, y, depth)
-                xm = utils.convert_2d_to_3d_oriented(calibration[1], x - 1, y, utils.parse_depth_smoothed(x - 1, y))
-                xp = utils.convert_2d_to_3d_oriented(calibration[1], x + 1, y, utils.parse_depth_smoothed(x + 1, y))
-                yp = utils.convert_2d_to_3d_oriented(calibration[1], x, y + 1, utils.parse_depth_smoothed(x, y + 1))
+                v = utils.convert_2d_to_3d_oriented(CALIBRATION[1], x, y, depth)
+                xm = utils.convert_2d_to_3d_oriented(CALIBRATION[1], x - 1, y, utils.parse_depth_smoothed(x - 1, y))
+                xp = utils.convert_2d_to_3d_oriented(CALIBRATION[1], x + 1, y, utils.parse_depth_smoothed(x + 1, y))
+                yp = utils.convert_2d_to_3d_oriented(CALIBRATION[1], x, y + 1, utils.parse_depth_smoothed(x, y + 1))
                 n = utils.norm(utils.cross(utils.diff(yp, xm), utils.diff(yp, xp)))
                 output[x][height + height - y - 1][0] = abs(n[0])
                 output[x][height + height - y - 1][1] = abs(n[1])

--- a/src/common/depthmap_toolkit/depthmap.py
+++ b/src/common/depthmap_toolkit/depthmap.py
@@ -90,7 +90,7 @@ def show_result():
                 vec = utils.convert_3d_to_2d(CALIBRATION[0], vec[0], vec[1], vec[2])
 
                 # depth data scaled to be visible
-                output[x][height - y - 1][:] = 1.0 - min(depth / 2.0, 1.0)
+                output[x][height - y - 1] = 1.0 - min(depth / 2.0, 1.0)
 
                 # depth data normal
                 v = utils.convert_2d_to_3d_oriented(CALIBRATION[1], x, y, depth)

--- a/src/common/depthmap_toolkit/depthmap.py
+++ b/src/common/depthmap_toolkit/depthmap.py
@@ -8,7 +8,9 @@ from PIL import Image
 
 import utils
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s - %(pathname)s: line %(lineno)d')
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s - %(pathname)s: line %(lineno)d')
 
 SUBPLOT_DEPTH = 0
 SUBPLOT_NORMAL = 1
@@ -17,6 +19,7 @@ SUBPLOT_CONFIDENCE = 3
 SUBPLOT_RGB = 4
 SUBPLOT_COUNT = 5
 
+
 def export(type, filename):
     if type == 'obj':
         utils.export_obj('export/' + filename, triangulate=True)
@@ -24,7 +27,7 @@ def export(type, filename):
         utils.export_pcd('export/' + filename)
 
 
-#click on data
+# click on data
 last = [0, 0, 0]
 
 
@@ -52,12 +55,12 @@ def onclick(event):
 
 def process(plt, dir_path, depth, rgb):
 
-    #extract depthmap
+    # extract depthmap
     with zipfile.ZipFile(dir_path + '/depth/' + depth, 'r') as zip_ref:
         zip_ref.extractall('.')
     utils.parse_data('data')
 
-    #read rgb data
+    # read rgb data
     global has_rgb
     global im_array
     if rgb:
@@ -70,7 +73,7 @@ def process(plt, dir_path, depth, rgb):
     else:
         has_rgb = 0
 
-    #parse calibration
+    # parse calibration
     global CALIBRATION
     CALIBRATION = utils.parse_calibration(dir_path + '/camera_calibration.txt')
 
@@ -85,7 +88,7 @@ def show_result():
         for y in range(height):
             depth = utils.parse_depth(x, y)
             if (depth):
-                #convert ToF coordinates into RGB coordinates
+                # convert ToF coordinates into RGB coordinates
                 vec = utils.convert_2d_to_3d(CALIBRATION[1], x, y, depth)
                 vec[0] += CALIBRATION[2][0]
                 vec[1] += CALIBRATION[2][1]

--- a/src/common/depthmap_toolkit/depthmap.py
+++ b/src/common/depthmap_toolkit/depthmap.py
@@ -77,7 +77,7 @@ def show_result():
     fig.canvas.mpl_connect('button_press_event', onclick)
     width = utils.getWidth()
     height = utils.getHeight()
-    output = np.zeros((width, height * 5, 3))
+    output = np.zeros((width, height * NUM_SUBPLOTS, 3))
     for x in range(width):
         for y in range(height):
             depth = utils.parse_depth(x, y)

--- a/src/common/depthmap_toolkit/depthmap.py
+++ b/src/common/depthmap_toolkit/depthmap.py
@@ -77,7 +77,7 @@ def show_result():
     fig.canvas.mpl_connect('button_press_event', onclick)
     width = utils.getWidth()
     height = utils.getHeight()
-    output = np.zeros((width, height * 3, 3))
+    output = np.zeros((width, height * 5, 3))
     for x in range(width):
         for y in range(height):
             depth = utils.parse_depth(x, y)
@@ -89,13 +89,35 @@ def show_result():
                 vec[2] += calibration[2][2]
                 vec = utils.convert_2d_to_3d(calibration[0], vec[0], vec[1], vec[2])
 
-                #set output pixel
-                output[x][height - y - 1][:] = 1.0 - min(depth / 2.0, 1.0)  # depth data scaled to be visible
-                output[x][height + height - y - 1][:] = utils.parse_confidence(x, y)
-                if output[x][height + height - y - 1][0] == 0:
-                    output[x][height + height - y - 1][:] = 1
+                # depth data scaled to be visible
+                output[x][height - y - 1][:] = 1.0 - min(depth / 2.0, 1.0)
+
+                # depth data normal
+                v = utils.convert_2d_to_3d_oriented(calibration[1], x, y, depth)
+                xm = utils.convert_2d_to_3d_oriented(calibration[1], x - 1, y, utils.parse_depth_smoothed(x - 1, y))
+                xp = utils.convert_2d_to_3d_oriented(calibration[1], x + 1, y, utils.parse_depth_smoothed(x + 1, y))
+                yp = utils.convert_2d_to_3d_oriented(calibration[1], x, y + 1, utils.parse_depth_smoothed(x, y + 1))
+                n = utils.norm(utils.cross(utils.diff(yp, xm), utils.diff(yp, xp)))
+                output[x][height + height - y - 1][0] = abs(n[0])
+                output[x][height + height - y - 1][1] = abs(n[1])
+                output[x][height + height - y - 1][2] = abs(n[2])
+
+                # world coordinates visualisation
+                horizontal = (v[1] % 0.1) * 10
+                vertical = (v[0] % 0.1) * 5 + (v[2] % 0.1) * 5
+                if abs(n[1]) < 0.5:
+                    output[x][2 * height + height - y - 1][0] = horizontal / (depth * depth)
+                if abs(n[1]) > 0.5:
+                    output[x][2 * height + height - y - 1][1] = vertical / (depth * depth)
+
+                # confidence value
+                output[x][3 * height + height - y - 1][:] = utils.parse_confidence(x, y)
+                if output[x][3 * height + height - y - 1][0] == 0:
+                    output[x][3 * height + height - y - 1][:] = 1
+
+                # RGB data
                 if vec[0] > 0 and vec[1] > 1 and vec[0] < width and vec[1] < height and has_rgb:
-                    output[x][2 * height + height - y - 1][0] = im_array[int(vec[1])][int(vec[0])][0] / 255.0
-                    output[x][2 * height + height - y - 1][1] = im_array[int(vec[1])][int(vec[0])][1] / 255.0
-                    output[x][2 * height + height - y - 1][2] = im_array[int(vec[1])][int(vec[0])][2] / 255.0
+                    output[x][4 * height + height - y - 1][0] = im_array[int(vec[1])][int(vec[0])][0] / 255.0
+                    output[x][4 * height + height - y - 1][1] = im_array[int(vec[1])][int(vec[0])][1] / 255.0
+                    output[x][4 * height + height - y - 1][2] = im_array[int(vec[1])][int(vec[0])][2] / 255.0
     plt.imshow(output)

--- a/src/common/depthmap_toolkit/utils.py
+++ b/src/common/depthmap_toolkit/utils.py
@@ -262,10 +262,10 @@ def parse_depth_smoothed(tx, ty):
     """Get average depth value from neighboring pixels"""
     depth_center = parse_depth(tx, ty)
     depth_x_minus = parse_depth(tx - 1, ty)
-    depthXPlus = parse_depth(tx + 1, ty)
-    depthYMinus = parse_depth(tx, ty - 1)
-    depthYPlus = parse_depth(tx, ty + 1)
-    return (depthXMinus + depthXPlus + depthYMinus + depthYPlus + depthCenter) / 5.0
+    depth_x_plus = parse_depth(tx + 1, ty)
+    depth_y_minus = parse_depth(tx, ty - 1)
+    depth_y_plus = parse_depth(tx, ty + 1)
+    return (depth_x_minus + depth_x_plus + depth_y_minus + depth_y_plus + depth_center) / 5.0
 
 
 def parse_numbers(line):

--- a/src/common/depthmap_toolkit/utils.py
+++ b/src/common/depthmap_toolkit/utils.py
@@ -20,12 +20,12 @@ def diff(a: list, b: list) -> list:
     return [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
 
 
-def norm(v: list):
-    """Difference of two vectors"""
+def norm(v: list) -> list:
+    """Vector normalize"""
     length = abs(v[0]) + abs(v[1]) + abs(v[2])
-    if len == 0:
-        len = 1
-    return [v[0] / len, v[1] / len, v[2] / len]
+    if length == 0:
+        length = 1
+    return [v[0] / length, v[1] / length, v[2] / length]
 
 
 def matrix_calculate(position: list, rotation: list) -> list:
@@ -258,12 +258,13 @@ def parse_depth(tx, ty):
 
 
 def parse_depth_smoothed(tx, ty):
-    d = parse_depth(tx, ty)
-    xm = parse_depth(tx - 1, ty)
-    xp = parse_depth(tx + 1, ty)
-    ym = parse_depth(tx, ty - 1)
-    yp = parse_depth(tx, ty + 1)
-    return (xm + xp + ym + yp + d) / 5.0
+    """Get average depth value from neightbour pixels"""
+    depthCenter = parse_depth(tx, ty)
+    depthXMinus = parse_depth(tx - 1, ty)
+    depthXPlus = parse_depth(tx + 1, ty)
+    depthYMinus = parse_depth(tx, ty - 1)
+    depthYPlus = parse_depth(tx, ty + 1)
+    return (depthXMinus  + depthXPlus + depthYMinus + depthYPlus + depthCenter) / 5.0
 
 
 def parse_numbers(line):

--- a/src/common/depthmap_toolkit/utils.py
+++ b/src/common/depthmap_toolkit/utils.py
@@ -2,7 +2,10 @@ import logging
 import logging.config
 import numpy as np
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s - %(pathname)s: line %(lineno)d')
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s - %(pathname)s: line %(lineno)d')
+
 
 def cross(a: list, b: list) -> list:
     """Cross product of two vectors"""
@@ -11,9 +14,11 @@ def cross(a: list, b: list) -> list:
          a[0] * b[1] - a[1] * b[0]]
     return c
 
+
 def diff(a: list, b: list) -> list:
     """Difference of two vectors"""
     return [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
+
 
 def norm(v: list):
     """Difference of two vectors"""
@@ -138,23 +143,27 @@ def export_obj(filename, triangulate):
             max_diff = 0.2
             for x in range(2, width - 2):
                 for y in range(2, height - 2):
-                    #get depth of all points of 2 potential triangles
+                    # get depth of all points of 2 potential triangles
                     d00 = parse_depth(x, y)
                     d10 = parse_depth(x + 1, y)
                     d01 = parse_depth(x, y + 1)
                     d11 = parse_depth(x + 1, y + 1)
 
-                    #check if first triangle points have existing indices
+                    # check if first triangle points have existing indices
                     if indices[x][y] > 0 and indices[x + 1][y] > 0 and indices[x][y + 1] > 0:
-                        #check if the triangle size is valid (to prevent generating triangle connecting child and background)
+                        # check if the triangle size is valid (to prevent generating triangle
+                        # connecting child and background)
                         if abs(d00 - d10) + abs(d00 - d01) + abs(d10 - d01) < max_diff:
-                            f.write('f ' + str(int(indices[x][y])) + ' ' + str(int(indices[x + 1][y])) + ' ' + str(int(indices[x][y + 1])) + '\n')
+                            f.write('f ' + str(int(indices[x][y])) + ' '
+                                    + str(int(indices[x + 1][y])) + ' ' + str(int(indices[x][y + 1])) + '\n')
 
-                    #check if second triangle points have existing indices
+                    # check if second triangle points have existing indices
                     if indices[x + 1][y + 1] > 0 and indices[x + 1][y] > 0 and indices[x][y + 1] > 0:
-                        #check if the triangle size is valid (to prevent generating triangle connecting child and background)
+                        # check if the triangle size is valid (to prevent generating triangle
+                        # connecting child and background)
                         if abs(d11 - d10) + abs(d11 - d01) + abs(d10 - d01) < max_diff:
-                            f.write('f ' + str(int(indices[x + 1][y + 1])) + ' ' + str(int(indices[x + 1][y])) + ' ' + str(int(indices[x][y + 1])) + '\n')
+                            f.write('f ' + str(int(indices[x + 1][y + 1])) + ' '
+                                    + str(int(indices[x + 1][y])) + ' ' + str(int(indices[x][y + 1])) + '\n')
         logging.info('Mesh exported into %s', filename)
 
 
@@ -203,13 +212,13 @@ def parse_calibration(filepath):
         CALIBRATION = []
         f.readline()[:-1]
         CALIBRATION.append(parse_numbers(f.readline()))
-        #logging.info(str(CALIBRATION[0]) + '\n') #color camera intrinsics - fx, fy, cx, cy
+        # logging.info(str(CALIBRATION[0]) + '\n') #color camera intrinsics - fx, fy, cx, cy
         f.readline()[:-1]
         CALIBRATION.append(parse_numbers(f.readline()))
-        #logging.info(str(CALIBRATION[1]) + '\n') #depth camera intrinsics - fx, fy, cx, cy
+        # logging.info(str(CALIBRATION[1]) + '\n') #depth camera intrinsics - fx, fy, cx, cy
         f.readline()[:-1]
         CALIBRATION.append(parse_numbers(f.readline()))
-        #logging.info(str(CALIBRATION[2]) + '\n') #depth camera position relativelly to color camera in meters
+        # logging.info(str(CALIBRATION[2]) + '\n') #depth camera position relativelly to color camera in meters
         CALIBRATION[2][1] *= 8.0  # workaround for wrong calibration data
     return CALIBRATION
 
@@ -247,6 +256,7 @@ def parse_depth(tx, ty):
     depth *= depthScale
     return depth
 
+
 def parse_depth_smoothed(tx, ty):
     d = parse_depth(tx, ty)
     xm = parse_depth(tx - 1, ty)
@@ -254,6 +264,7 @@ def parse_depth_smoothed(tx, ty):
     ym = parse_depth(tx, ty - 1)
     yp = parse_depth(tx, ty + 1)
     return (xm + xp + ym + yp + d) / 5.0
+
 
 def parse_numbers(line):
     """Parse line of numbers"""

--- a/src/common/depthmap_toolkit/utils.py
+++ b/src/common/depthmap_toolkit/utils.py
@@ -261,7 +261,7 @@ def parse_depth(tx, ty):
 def parse_depth_smoothed(tx, ty):
     """Get average depth value from neightbour pixels"""
     depth_center = parse_depth(tx, ty)
-    depthXMinus = parse_depth(tx - 1, ty)
+    depth_x_minus = parse_depth(tx - 1, ty)
     depthXPlus = parse_depth(tx + 1, ty)
     depthYMinus = parse_depth(tx, ty - 1)
     depthYPlus = parse_depth(tx, ty + 1)

--- a/src/common/depthmap_toolkit/utils.py
+++ b/src/common/depthmap_toolkit/utils.py
@@ -259,7 +259,7 @@ def parse_depth(tx, ty):
 
 
 def parse_depth_smoothed(tx, ty):
-    """Get average depth value from neightbour pixels"""
+    """Get average depth value from neighboring pixels"""
     depth_center = parse_depth(tx, ty)
     depth_x_minus = parse_depth(tx - 1, ty)
     depthXPlus = parse_depth(tx + 1, ty)

--- a/src/common/depthmap_toolkit/utils.py
+++ b/src/common/depthmap_toolkit/utils.py
@@ -260,7 +260,7 @@ def parse_depth(tx, ty):
 
 def parse_depth_smoothed(tx, ty):
     """Get average depth value from neightbour pixels"""
-    depthCenter = parse_depth(tx, ty)
+    depth_center = parse_depth(tx, ty)
     depthXMinus = parse_depth(tx - 1, ty)
     depthXPlus = parse_depth(tx + 1, ty)
     depthYMinus = parse_depth(tx, ty - 1)

--- a/src/common/depthmap_toolkit/utils.py
+++ b/src/common/depthmap_toolkit/utils.py
@@ -22,7 +22,7 @@ def diff(a: list, b: list) -> list:
 
 def norm(v: list):
     """Difference of two vectors"""
-    len = abs(v[0]) + abs(v[1]) + abs(v[2])
+    length = abs(v[0]) + abs(v[1]) + abs(v[2])
     if len == 0:
         len = 1
     return [v[0] / len, v[1] / len, v[2] / len]

--- a/src/common/depthmap_toolkit/utils.py
+++ b/src/common/depthmap_toolkit/utils.py
@@ -237,6 +237,8 @@ def parse_data(filename):
 
 def parse_depth(tx, ty):
     """Get depth of the point in meters"""
+    if tx < 1 or ty < 1 or tx >= width or ty >= height:
+        return 0
     depth = data[(int(ty) * width + int(tx)) * 3 + 0] << 8
     depth += data[(int(ty) * width + int(tx)) * 3 + 1]
     depth *= depthScale
@@ -244,14 +246,11 @@ def parse_depth(tx, ty):
 
 def parse_depth_smoothed(tx, ty):
     d = parse_depth(tx, ty)
-    if tx > 1 and tx < width - 1 and ty > 1 and ty < height - 1:
-        xm = parse_depth(tx - 1, ty)
-        xp = parse_depth(tx + 1, ty)
-        ym = parse_depth(tx, ty - 1)
-        yp = parse_depth(tx, ty + 1)
-        return (xm + xp + ym + yp + d) / 5.0
-    return d
-
+    xm = parse_depth(tx - 1, ty)
+    xp = parse_depth(tx + 1, ty)
+    ym = parse_depth(tx, ty - 1)
+    yp = parse_depth(tx, ty + 1)
+    return (xm + xp + ym + yp + d) / 5.0
 
 def parse_numbers(line):
     """Parse line of numbers"""

--- a/src/common/depthmap_toolkit/utils.py
+++ b/src/common/depthmap_toolkit/utils.py
@@ -4,6 +4,24 @@ import numpy as np
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s - %(pathname)s: line %(lineno)d')
 
+def cross(a: list, b: list) -> list:
+    """Cross product of two vectors"""
+    c = [a[1] * b[2] - a[2] * b[1],
+         a[2] * b[0] - a[0] * b[2],
+         a[0] * b[1] - a[1] * b[0]]
+    return c
+
+def diff(a: list, b: list) -> list:
+    """Difference of two vectors"""
+    return [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
+
+def norm(v: list):
+    """Difference of two vectors"""
+    len = abs(v[0]) + abs(v[1]) + abs(v[2])
+    if len == 0:
+        len = 1
+    return [v[0] / len, v[1] / len, v[2] / len]
+
 
 def matrix_calculate(position: list, rotation: list) -> list:
     """Calculate a matrix image->world from device position and rotation"""
@@ -223,6 +241,16 @@ def parse_depth(tx, ty):
     depth += data[(int(ty) * width + int(tx)) * 3 + 1]
     depth *= depthScale
     return depth
+
+def parse_depth_smoothed(tx, ty):
+    d = parse_depth(tx, ty)
+    if tx > 1 and tx < width - 1 and ty > 1 and ty < height - 1:
+        xm = parse_depth(tx - 1, ty)
+        xp = parse_depth(tx + 1, ty)
+        ym = parse_depth(tx, ty - 1)
+        yp = parse_depth(tx, ty + 1)
+        return (xm + xp + ym + yp + d) / 5.0
+    return d
 
 
 def parse_numbers(line):

--- a/src/common/depthmap_toolkit/utils.py
+++ b/src/common/depthmap_toolkit/utils.py
@@ -265,7 +265,7 @@ def parse_depth_smoothed(tx, ty):
     depthXPlus = parse_depth(tx + 1, ty)
     depthYMinus = parse_depth(tx, ty - 1)
     depthYPlus = parse_depth(tx, ty + 1)
-    return (depthXMinus  + depthXPlus + depthYMinus + depthYPlus + depthCenter) / 5.0
+    return (depthXMinus + depthXPlus + depthYMinus + depthYPlus + depthCenter) / 5.0
 
 
 def parse_numbers(line):

--- a/src/common/depthmap_toolkit/utils.py
+++ b/src/common/depthmap_toolkit/utils.py
@@ -98,6 +98,7 @@ def convert_2d_to_3d_oriented(intrisics: list, x: float, y: float, z: float) -> 
     res = convert_2d_to_3d(CALIBRATION[1], x, y, z)
     if res:
         try:
+            # special case for Google Tango devices with different rotation
             if width == 180 and height == 135:
                 res = [res[0], -res[1], res[2]]
             else:

--- a/src/common/depthmap_toolkit/utils.py
+++ b/src/common/depthmap_toolkit/utils.py
@@ -93,7 +93,10 @@ def convert_2d_to_3d_oriented(intrisics: list, x: float, y: float, z: float) -> 
     res = convert_2d_to_3d(CALIBRATION[1], x, y, z)
     if res:
         try:
-            res = [-res[0], res[1], res[2]]
+            if width == 180 and height == 135:
+                res = [res[0], -res[1], res[2]]
+            else:
+                res = [-res[0], res[1], res[2]]
             res = matrix_transform_point(res, matrix)
             res = [res[0], -res[1], res[2]]
         except NameError:


### PR DESCRIPTION
# Description

Updated camera pose calculation (scan type v1.0), visualisation of surface normal in world coordinates and repeating pattern visualisation which might help to solve ML models HW dependency.

Scan type v1.0 updates:
https://dev.azure.com/cgmorg/ChildGrowthMonitor/_workitems/edit/1059
https://dev.azure.com/cgmorg/ChildGrowthMonitor/_workitems/edit/1047
https://dev.azure.com/cgmorg/ChildGrowthMonitor/_workitems/edit/1024

# How Has This Been Tested?
The depthmaps from Samsung Note10+, Huawei P30 Pro and Lenovo Phab 2 Pro were all tested with moving/rotating camera to confirm validity of normals orientation, surface pattern. Examples:

Samsung Note10+
![note10+](https://user-images.githubusercontent.com/6472545/112793373-7f7e1c80-9065-11eb-80ff-2451147c6380.png)
Lenovo Phab 2 Pro
![lenovo_180x135](https://user-images.githubusercontent.com/6472545/112793378-80af4980-9065-11eb-9a94-b0178d27a3eb.png)
Huawei P30 Pro
![p30pro](https://user-images.githubusercontent.com/6472545/112793381-8147e000-9065-11eb-83e9-35552bade594.png)

