### PR TITLE
Filter for training codes

### DIFF
--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/src/config.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/src/config.py
@@ -21,6 +21,5 @@ CONFIG = Bunch(dict(
 
     # Parameters for dataset generation.
     TARGET_INDEXES=[0],  # 0 is height, 1 is weight.
-    # CODES=['100', '101', '102', '200', '201', '202'],
-    CODES=['100', '101', '102'],
+    CODES=['100', '101', '102', '200', '201', '202'],
 ))

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/src/config.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/src/config.py
@@ -21,4 +21,6 @@ CONFIG = Bunch(dict(
 
     # Parameters for dataset generation.
     TARGET_INDEXES=[0],  # 0 is height, 1 is weight.
+    # CODES=['100', '101', '102', '200', '201', '202'],
+    CODES=['100', '101', '102'],
 ))

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/src/train.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/src/train.py
@@ -96,7 +96,8 @@ assert len(qrcode_paths_training) > 0 and len(qrcode_paths_validate) > 0
 def get_depthmap_files(paths):
     pickle_paths = []
     for path in paths:
-        pickle_paths.extend(glob.glob(os.path.join(path, "**", "*.p")))
+        for code in CONFIG.CODES:
+            pickle_paths.extend(glob.glob(os.path.join(path, code, "*.p")))
     return pickle_paths
 
 

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/src/train.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/src/train.py
@@ -12,7 +12,7 @@ from azureml.core.run import Run
 import wandb
 from wandb.keras import WandbCallback
 
-from config_weight import CONFIG
+from config import CONFIG
 from constants import MODEL_CKPT_FILENAME, REPO_DIR
 from model import create_cnn
 from train_util import copy_dir

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/train_notebook.ipynb
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/train_notebook.ipynb
@@ -53,7 +53,7 @@
    "source": [
     "dataset_name = \"anon-depthmap-95k\"  # \"anon-depthmap-mini\"\n",
     "experiment_name = \"q3-depthmap-plaincnn-height-95k\"\n",
-    "tags = {\"filter\": \"100qrcodes\", \"CODES\": \"['100', '101', '102']\"}"
+    "tags = {}"
    ]
   },
   {

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/train_notebook.ipynb
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/train_notebook.ipynb
@@ -53,7 +53,7 @@
    "source": [
     "dataset_name = \"anon-depthmap-95k\"  # \"anon-depthmap-mini\"\n",
     "experiment_name = \"q3-depthmap-plaincnn-height-95k\"\n",
-    "tags = {}"
+    "tags = {\"filter\": \"100qrcodes\", \"CODES\": \"['100', '101', '102']\"}"
    ]
   },
   {


### PR DESCRIPTION
**Motivation:** There was the idea of training on a subset of training data, e.g. only standing children.

**Solution**: In order to allow this CNN and M-CNN should parse a list with codes (aka scan steps) and only use the ones for training that are configured