### PR TITLE
depthmap toolkit exports textured OBJs

### DIFF
--- a/src/common/depthmap_toolkit/depthmap.py
+++ b/src/common/depthmap_toolkit/depthmap.py
@@ -21,8 +21,9 @@ SUBPLOT_COUNT = 5
 
 
 def export(type, filename):
+    rgb = current_rgb
     if type == 'obj':
-        utils.export_obj('export/' + filename, triangulate=True)
+        utils.export_obj('export/' + filename, rgb, triangulate=True)
     if type == 'pcd':
         utils.export_pcd('export/' + filename)
 
@@ -61,16 +62,19 @@ def process(plt, dir_path, depth, rgb):
     utils.parse_data('data')
 
     # read rgb data
+    global current_rgb
     global has_rgb
     global im_array
     if rgb:
+        current_rgb = dir_path + '/rgb/' + rgb
         has_rgb = 1
         width = utils.getWidth()
         height = utils.getHeight()
-        pil_im = Image.open(dir_path + '/rgb/' + rgb)
+        pil_im = Image.open(current_rgb)
         pil_im = pil_im.resize((width, height), Image.ANTIALIAS)
         im_array = np.asarray(pil_im)
     else:
+        current_rgb = rgb
         has_rgb = 0
 
     # parse calibration

--- a/src/common/depthmap_toolkit/depthmap.py
+++ b/src/common/depthmap_toolkit/depthmap.py
@@ -62,7 +62,7 @@ def process(plt, dir_path, depth, rgb):
     utils.parse_data('data')
 
     # read rgb data
-    global current_rgb
+    global CURRENT_RGB
     global has_rgb
     global im_array
     if rgb:

--- a/src/common/depthmap_toolkit/depthmap.py
+++ b/src/common/depthmap_toolkit/depthmap.py
@@ -21,7 +21,7 @@ SUBPLOT_COUNT = 5
 
 
 def export(type, filename):
-    rgb = current_rgb
+    rgb = CURRENT_RGB
     if type == 'obj':
         utils.export_obj('export/' + filename, rgb, triangulate=True)
     if type == 'pcd':
@@ -63,19 +63,19 @@ def process(plt, dir_path, depth, rgb):
 
     # read rgb data
     global CURRENT_RGB
-    global has_rgb
-    global im_array
+    global HAS_RGB
+    global IM_ARRAY
     if rgb:
-        current_rgb = dir_path + '/rgb/' + rgb
-        has_rgb = 1
+        CURRENT_RGB = dir_path + '/rgb/' + rgb
+        HAS_RGB = 1
         width = utils.getWidth()
         height = utils.getHeight()
-        pil_im = Image.open(current_rgb)
+        pil_im = Image.open(CURRENT_RGB)
         pil_im = pil_im.resize((width, height), Image.ANTIALIAS)
-        im_array = np.asarray(pil_im)
+        IM_ARRAY = np.asarray(pil_im)
     else:
-        current_rgb = rgb
-        has_rgb = 0
+        CURRENT_RGB = rgb
+        HAS_RGB = 0
 
     # parse calibration
     global CALIBRATION
@@ -126,8 +126,8 @@ def show_result():
                     output[x][SUBPLOT_CONFIDENCE * height + height - y - 1][:] = 1
 
                 # RGB data
-                if vec[0] > 0 and vec[1] > 1 and vec[0] < width and vec[1] < height and has_rgb:
-                    output[x][SUBPLOT_RGB * height + height - y - 1][0] = im_array[int(vec[1])][int(vec[0])][0] / 255.0
-                    output[x][SUBPLOT_RGB * height + height - y - 1][1] = im_array[int(vec[1])][int(vec[0])][1] / 255.0
-                    output[x][SUBPLOT_RGB * height + height - y - 1][2] = im_array[int(vec[1])][int(vec[0])][2] / 255.0
+                if vec[0] > 0 and vec[1] > 1 and vec[0] < width and vec[1] < height and HAS_RGB:
+                    output[x][SUBPLOT_RGB * height + height - y - 1][0] = IM_ARRAY[int(vec[1])][int(vec[0])][0] / 255.0
+                    output[x][SUBPLOT_RGB * height + height - y - 1][1] = IM_ARRAY[int(vec[1])][int(vec[0])][1] / 255.0
+                    output[x][SUBPLOT_RGB * height + height - y - 1][2] = IM_ARRAY[int(vec[1])][int(vec[0])][2] / 255.0
     plt.imshow(output)

--- a/src/common/depthmap_toolkit/utils.py
+++ b/src/common/depthmap_toolkit/utils.py
@@ -132,7 +132,7 @@ def export_obj(filename, rgb, triangulate):
     indices = np.zeros((width, height))
     material = filename[:len(filename) - 4] + '.mtl'
     if rgb:
-       with open(material, 'w') as f:
+        with open(material, 'w') as f:
             f.write('newmtl default\n')
             f.write('map_Kd ../' + rgb + '\n')
 

--- a/src/common/depthmap_toolkit/utils.py
+++ b/src/common/depthmap_toolkit/utils.py
@@ -121,15 +121,25 @@ def convert_3d_to_2d(intrisics: list, x: float, y: float, z: float) -> list:
     return [tx, ty, z]
 
 
-def export_obj(filename, triangulate):
+def export_obj(filename, rgb, triangulate):
     """
 
     triangulate=True generates OBJ of type mesh
     triangulate=False generates OBJ of type pointcloud
+    rgb=path to color frame
     """
     count = 0
     indices = np.zeros((width, height))
+    material = filename[:len(filename) - 4] + '.mtl'
+    if rgb:
+       with open(material, 'w') as f:
+            f.write('newmtl default\n')
+            f.write('map_Kd ../' + rgb + '\n')
+
     with open(filename, 'w') as f:
+        if rgb:
+            f.write('mtllib ' + material[filename.index('/') + 1:] + '\n')
+            f.write('usemtl default\n')
         for x in range(2, width - 2):
             for y in range(2, height - 2):
                 depth = parse_depth(x, y)
@@ -139,6 +149,7 @@ def export_obj(filename, triangulate):
                         count = count + 1
                         indices[x][y] = count  # add index of written vertex into array
                         f.write('v ' + str(res[0]) + ' ' + str(res[1]) + ' ' + str(res[2]) + '\n')
+                        f.write('vt ' + str(x / width) + ' ' + str(1 - y / height) + '\n')
 
         if triangulate:
             max_diff = 0.2
@@ -155,16 +166,20 @@ def export_obj(filename, triangulate):
                         # check if the triangle size is valid (to prevent generating triangle
                         # connecting child and background)
                         if abs(d00 - d10) + abs(d00 - d01) + abs(d10 - d01) < max_diff:
-                            f.write('f ' + str(int(indices[x][y])) + ' '
-                                    + str(int(indices[x + 1][y])) + ' ' + str(int(indices[x][y + 1])) + '\n')
+                            a = str(int(indices[x][y]))
+                            b = str(int(indices[x + 1][y]))
+                            c = str(int(indices[x][y + 1]))
+                            f.write('f ' + a + '/' + a + ' ' + b + '/' + b + ' ' + c + '/' + c + '\n')
 
                     # check if second triangle points have existing indices
                     if indices[x + 1][y + 1] > 0 and indices[x + 1][y] > 0 and indices[x][y + 1] > 0:
                         # check if the triangle size is valid (to prevent generating triangle
                         # connecting child and background)
                         if abs(d11 - d10) + abs(d11 - d01) + abs(d10 - d01) < max_diff:
-                            f.write('f ' + str(int(indices[x + 1][y + 1])) + ' '
-                                    + str(int(indices[x + 1][y])) + ' ' + str(int(indices[x][y + 1])) + '\n')
+                            a = str(int(indices[x + 1][y + 1]))
+                            b = str(int(indices[x + 1][y]))
+                            c = str(int(indices[x][y + 1]))
+                            f.write('f ' + a + '/' + a + ' ' + b + '/' + b + ' ' + c + '/' + c + '\n')
         logging.info('Mesh exported into %s', filename)
 
 

--- a/src/common/depthmap_toolkit/utils.py
+++ b/src/common/depthmap_toolkit/utils.py
@@ -130,6 +130,8 @@ def export_obj(filename, rgb, triangulate):
     """
     count = 0
     indices = np.zeros((width, height))
+
+    # create MTL file (a standart extension of OBJ files to define geometry materials and textures)
     material = filename[:len(filename) - 4] + '.mtl'
     if rgb:
         with open(material, 'w') as f:
@@ -169,6 +171,7 @@ def export_obj(filename, rgb, triangulate):
                             a = str(int(indices[x][y]))
                             b = str(int(indices[x + 1][y]))
                             c = str(int(indices[x][y + 1]))
+                            # define triangle indices in (world coordinates / texture coordinates)
                             f.write('f ' + a + '/' + a + ' ' + b + '/' + b + ' ' + c + '/' + c + '\n')
 
                     # check if second triangle points have existing indices
@@ -179,6 +182,7 @@ def export_obj(filename, rgb, triangulate):
                             a = str(int(indices[x + 1][y + 1]))
                             b = str(int(indices[x + 1][y]))
                             c = str(int(indices[x][y + 1]))
+                            # define triangle indices in (world coordinates / texture coordinates)
                             f.write('f ' + a + '/' + a + ' ' + b + '/' + b + ' ' + c + '/' + c + '\n')
         logging.info('Mesh exported into %s', filename)
 


### PR DESCRIPTION
# Description

This PR adds RGB mapping when using OBJ export in depthmap toolkit. Using that we can get a textured model from RGBD data.
![unoriented](https://user-images.githubusercontent.com/6472545/115358248-bf947300-a1bd-11eb-83ce-7140f63a8df3.png)
![oriented](https://user-images.githubusercontent.com/6472545/115358262-c4f1bd80-a1bd-11eb-84f3-f3b1cd5db1b0.png)

Note: in the second image there is missing part of body because from the device perspective it was not visible (covered by a hand).

User story # (US link)
https://dev.azure.com/cgmorg/ChildGrowthMonitor/_workitems/edit/1223

# How Has This Been Tested?

I did a visual check using data captured by Huawei, Lenovo and Samsung:
* Huawei produces high quality RGBD alignment and exported models look perfect
* Lenovo has a good RGBD alignment but depthmap toolkit does not support unordered data (which means there is needed to set as input a single depthmap and single rgb frame to prevent mistmatch). Exported models look very good
* Samsung does not have a valid lens calibration and because of it the exported model is not correctly aligned

All results as expected