### PR TITLE
Depthmap toolkit vertex order fixed when exporting OBJ

### DIFF
--- a/src/common/depthmap_toolkit/utils.py
+++ b/src/common/depthmap_toolkit/utils.py
@@ -168,9 +168,9 @@ def export_obj(filename, rgb, triangulate):
                         # check if the triangle size is valid (to prevent generating triangle
                         # connecting child and background)
                         if abs(d00 - d10) + abs(d00 - d01) + abs(d10 - d01) < max_diff:
-                            a = str(int(indices[x][y]))
+                            c = str(int(indices[x][y]))
                             b = str(int(indices[x + 1][y]))
-                            c = str(int(indices[x][y + 1]))
+                            a = str(int(indices[x][y + 1]))
                             # define triangle indices in (world coordinates / texture coordinates)
                             f.write('f ' + a + '/' + a + ' ' + b + '/' + b + ' ' + c + '/' + c + '\n')
 


### PR DESCRIPTION
# Description

Exported OBJ from depthmap toolkit had for odd triangles wrong vertex order which caused in some programs incorrect shading or missing triangles:
![vertex_order](https://user-images.githubusercontent.com/6472545/117280023-7bae9880-ae62-11eb-9efc-2c6e90fc9750.png)

User story https://dev.azure.com/cgmorg/ChildGrowthMonitor/_workitems/edit/1307
