### PR TITLE
Depthmap toolkit logs angle between camera and floor

### DIFF
--- a/src/common/depthmap_toolkit/depthmap.py
+++ b/src/common/depthmap_toolkit/depthmap.py
@@ -82,12 +82,12 @@ def process(plt, dir_path, depth, rgb):
     global CALIBRATION
     CALIBRATION = utils.parse_calibration(dir_path + '/camera_calibration.txt')
 
-def show_angle_between_camera_and_floor():
+def get_angle_between_camera_and_floor():
     centerx = float(utils.getWidth() / 2)
     centery = float(utils.getHeight() / 2)
     vector = utils.convert_2d_to_3d_oriented(CALIBRATION[1], centerx, centery, 1.0)
     angle = 90 + math.degrees(math.atan2(vector[0], vector[1]))
-    logging.info('angle between camera and floor is %f', angle)
+    return angle
 
 
 def show_result():

--- a/src/common/depthmap_toolkit/depthmap.py
+++ b/src/common/depthmap_toolkit/depthmap.py
@@ -1,8 +1,8 @@
 import zipfile
 import logging
 import logging.config
-
 import math
+
 import matplotlib.pyplot as plt
 import numpy as np
 from PIL import Image

--- a/src/common/depthmap_toolkit/depthmap.py
+++ b/src/common/depthmap_toolkit/depthmap.py
@@ -85,8 +85,8 @@ def process(plt, dir_path, depth, rgb):
     # show angle between camera and floor
     centerx = float(utils.getWidth() / 2)
     centery = float(utils.getHeight() / 2)
-    dir = utils.convert_2d_to_3d_oriented(CALIBRATION[1], centerx, centery, 1.0)
-    angle = 90 + math.degrees(math.atan2(dir[0], dir[1]))
+    vector = utils.convert_2d_to_3d_oriented(CALIBRATION[1], centerx, centery, 1.0)
+    angle = 90 + math.degrees(math.atan2(vector[0], vector[1]))
     logging.info('angle between camera and floor is %f', angle)
 
 

--- a/src/common/depthmap_toolkit/depthmap.py
+++ b/src/common/depthmap_toolkit/depthmap.py
@@ -2,6 +2,7 @@ import zipfile
 import logging
 import logging.config
 
+import math
 import matplotlib.pyplot as plt
 import numpy as np
 from PIL import Image
@@ -81,6 +82,12 @@ def process(plt, dir_path, depth, rgb):
     global CALIBRATION
     CALIBRATION = utils.parse_calibration(dir_path + '/camera_calibration.txt')
 
+    # show angle between camera and floor
+    centerx = float(utils.getWidth() / 2)
+    centery = float(utils.getHeight() / 2)
+    dir = utils.convert_2d_to_3d_oriented(CALIBRATION[1], centerx, centery, 1.0)
+    angle = 90 + math.degrees(math.atan2(dir[0], dir[1]))
+    logging.info('angle between camera and floor is %f', angle)
 
 def show_result():
     fig = plt.figure()

--- a/src/common/depthmap_toolkit/depthmap.py
+++ b/src/common/depthmap_toolkit/depthmap.py
@@ -82,6 +82,7 @@ def process(plt, dir_path, depth, rgb):
     global CALIBRATION
     CALIBRATION = utils.parse_calibration(dir_path + '/camera_calibration.txt')
 
+
 def get_angle_between_camera_and_floor():
     centerx = float(utils.getWidth() / 2)
     centery = float(utils.getHeight() / 2)

--- a/src/common/depthmap_toolkit/depthmap.py
+++ b/src/common/depthmap_toolkit/depthmap.py
@@ -82,7 +82,7 @@ def process(plt, dir_path, depth, rgb):
     global CALIBRATION
     CALIBRATION = utils.parse_calibration(dir_path + '/camera_calibration.txt')
 
-    # show angle between camera and floor
+def show_angle_between_camera_and_floor():
     centerx = float(utils.getWidth() / 2)
     centery = float(utils.getHeight() / 2)
     vector = utils.convert_2d_to_3d_oriented(CALIBRATION[1], centerx, centery, 1.0)

--- a/src/common/depthmap_toolkit/depthmap.py
+++ b/src/common/depthmap_toolkit/depthmap.py
@@ -89,6 +89,7 @@ def process(plt, dir_path, depth, rgb):
     angle = 90 + math.degrees(math.atan2(dir[0], dir[1]))
     logging.info('angle between camera and floor is %f', angle)
 
+
 def show_result():
     fig = plt.figure()
     fig.canvas.mpl_connect('button_press_event', onclick)

--- a/src/common/depthmap_toolkit/toolkit.py
+++ b/src/common/depthmap_toolkit/toolkit.py
@@ -12,7 +12,9 @@ from matplotlib.widgets import Button
 import depthmap
 import pcd2depth
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s - %(pathname)s: line %(lineno)d')
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s - %(pathname)s: line %(lineno)d')
 
 DEPTHMAP_DIR = None
 
@@ -67,7 +69,7 @@ def show(depthmap_dir):
         depthmap.process(plt, depthmap_dir, depth[index], rgb[index])
     else:
         depthmap.process(plt, depthmap_dir, depth[index], 0)
-    angle = depthmap.get_angle_between_camera_and_floor();
+    angle = depthmap.get_angle_between_camera_and_floor()
     logging.info('angle between camera and floor is %f', angle)
 
     depthmap.show_result()

--- a/src/common/depthmap_toolkit/toolkit.py
+++ b/src/common/depthmap_toolkit/toolkit.py
@@ -67,6 +67,8 @@ def show(depthmap_dir):
         depthmap.process(plt, depthmap_dir, depth[index], rgb[index])
     else:
         depthmap.process(plt, depthmap_dir, depth[index], 0)
+    angle = depthmap.get_angle_between_camera_and_floor();
+    logging.info('angle between camera and floor is %f', angle)
 
     depthmap.show_result()
     ax = plt.gca()


### PR DESCRIPTION
# Description

This PR adds an example how to calculate an angle between camera and floor with depthmap toolkit:
![angle](https://user-images.githubusercontent.com/6472545/117768357-90a87480-b232-11eb-9345-2c7c014b686c.gif)

#### Values
* 90 degrees - camera is pointing to ceiling
* 0 degrees - camera is pointing to horizont (parallel to floor)
* -90 degrees - camera is pointing to floor

#### Notes
* The input data has to use scan type v0.9 or higher
* If the phone was exposed during scanning to a strong magnet then the values might be wrong

#### User story 
https://dev.azure.com/cgmorg/ChildGrowthMonitor/_workitems/edit/1050

# How Has This Been Tested?

It was tested by multiple checking math formula and validating output values.