### PR TITLE
Depthmap exporter revision: floor alignment

### DIFF
--- a/src/common/depthmap_toolkit/exporter.py
+++ b/src/common/depthmap_toolkit/exporter.py
@@ -11,9 +11,11 @@ logging.basicConfig(
 
 def export_obj(filename: str,
                dmap: Depthmap,
+               floor: float,
                triangulate: bool):
     """Export .obj file, which can be visualized in tools like Meshlab.
 
+    floor is the floor altitude to align floor to Y=zero
     triangulate=True generates OBJ of type mesh
     triangulate=False generates OBJ of type pointcloud
     """
@@ -41,7 +43,7 @@ def export_obj(filename: str,
                     continue
                 count = count + 1
                 indices[x][y] = count  # add index of written vertex into array
-                f.write('v ' + str(res[0]) + ' ' + str(res[1]) + ' ' + str(res[2]) + '\n')
+                f.write('v ' + str(res[0]) + ' ' + str(res[1] - floor) + ' ' + str(res[2]) + '\n')
                 f.write('vt ' + str(x / dmap.width) + ' ' + str(1 - y / dmap.height) + '\n')
 
         if triangulate:

--- a/src/common/depthmap_toolkit/exporter.py
+++ b/src/common/depthmap_toolkit/exporter.py
@@ -11,11 +11,11 @@ logging.basicConfig(
 
 def export_obj(filename: str,
                dmap: Depthmap,
-               floor: float,
+               floor_altitude_in_meters: float,
                triangulate: bool):
     """Export .obj file, which can be visualized in tools like Meshlab.
 
-    floor is the floor altitude to align floor to Y=zero
+    floor_altitude_in_meters is the floor altitude to align floor to Y=zero
     triangulate=True generates OBJ of type mesh
     triangulate=False generates OBJ of type pointcloud
     """
@@ -43,7 +43,8 @@ def export_obj(filename: str,
                     continue
                 count = count + 1
                 indices[x][y] = count  # add index of written vertex into array
-                f.write('v ' + str(res[0]) + ' ' + str(res[1] - floor) + ' ' + str(res[2]) + '\n')
+                res[1] = res[1] - floor_altitude_in_meters
+                f.write('v ' + str(res[0]) + ' ' + str(res[1]) + ' ' + str(res[2]) + '\n')
                 f.write('vt ' + str(x / dmap.width) + ' ' + str(1 - y / dmap.height) + '\n')
 
         if triangulate:

--- a/src/common/depthmap_toolkit/toolkit.py
+++ b/src/common/depthmap_toolkit/toolkit.py
@@ -51,8 +51,9 @@ def onclick(event):
 
 def export_object(event):
     global DMAP
+    floor = DMAP.get_floor_level()
     fname = f'output{INDEX}.obj'
-    export_obj('export/' + fname, DMAP, triangulate=True)
+    export_obj('export/' + fname, DMAP, floor, triangulate=True)
 
 
 def export_pointcloud(event):

--- a/src/common/depthmap_toolkit/toolkit.py
+++ b/src/common/depthmap_toolkit/toolkit.py
@@ -87,7 +87,7 @@ def show(depthmap_dir: str, calibration_file: str):
     angle = DMAP.get_angle_between_camera_and_floor()
     logging.info('angle between camera and floor is %f', angle)
 
-    render_plot(DMAP)
+    plt.imshow(render_plot(DMAP))
     plt.show()
 
 

--- a/src/common/depthmap_toolkit/visualisation.py
+++ b/src/common/depthmap_toolkit/visualisation.py
@@ -1,7 +1,6 @@
 import logging
 import logging.config
 
-import matplotlib.pyplot as plt
 import numpy as np
 
 from constants import MASK_CHILD
@@ -86,7 +85,7 @@ def render_pixel(output: object,
         output[x][index][2] = min(max(0, output[x][index][2]), 1)
 
 
-def render_plot(dmap: Depthmap):
+def render_plot(dmap: Depthmap) -> np.array:
     # floor and child detection
     floor = dmap.get_floor_level()
     mask, highest = dmap.detect_child(floor)
@@ -98,4 +97,4 @@ def render_plot(dmap: Depthmap):
             render_pixel(output, x, y, floor, mask, dmap)
 
     logging.info('height=%fm', highest - floor)
-    plt.imshow(output)
+    return output


### PR DESCRIPTION
# Description

The floor alignment is necessary to make the work with the exported model user friendly.
Additionally I made visualisation.py independent of matplotlib, this way it could be used with another rendering systems.

User story https://dev.azure.com/cgmorg/ChildGrowthMonitor/_workitems/edit/1477

# How Has This Been Tested?

By exporting multiple OBJs and checking if the floor alignment is correct (using Blender)
