### PR TITLE
Depthmap toolkit - Visualisation refactor

### DIFF
--- a/src/common/depthmap_toolkit/tests/test_depthmap.py
+++ b/src/common/depthmap_toolkit/tests/test_depthmap.py
@@ -40,8 +40,8 @@ def test_depthmap():
 
 def test_get_highest_point():
     depthmap_dir = str(TOOLKIT_DIR / 'huawei_p40pro')
-    depthmap_fname = 'depth_dog_1622182020448_100_234.depth'
-    rgb_fname = 'rgb_dog_1622182020448_100_234.jpg'
+    depthmap_fname = 'depth_dog_1622182020448_100_282.depth'
+    rgb_fname = 'rgb_dog_1622182020448_100_282.jpg'
     calibration_file = str(TOOLKIT_DIR / 'huawei_p40pro' / 'camera_calibration.txt')
     dmap = Depthmap.create_from_file(depthmap_dir, depthmap_fname, rgb_fname, calibration_file)
 

--- a/src/common/depthmap_toolkit/tests/test_visualisation.py
+++ b/src/common/depthmap_toolkit/tests/test_visualisation.py
@@ -5,7 +5,7 @@ import numpy as np
 
 sys.path.append('./src/common/depthmap_toolkit')
 from depthmap import Depthmap  # noqa: E402
-from visualisation import blur_face, render_rgb # noqa: E402
+from visualisation import blur_face, render_rgb  # noqa: E402
 
 TOOLKIT_DIR = Path(__file__).parents[0].absolute()
 OFFSET_X_Y = (0.37, 0.53)

--- a/src/common/depthmap_toolkit/tests/test_visualisation.py
+++ b/src/common/depthmap_toolkit/tests/test_visualisation.py
@@ -5,7 +5,7 @@ import numpy as np
 
 sys.path.append('./src/common/depthmap_toolkit')
 from depthmap import Depthmap  # noqa: E402
-from visualisation import blur_face, render_pixel, SUBPLOT_RGB, SUBPLOT_COUNT  # noqa: E402
+from visualisation import blur_face, render_rgb # noqa: E402
 
 TOOLKIT_DIR = Path(__file__).parents[0].absolute()
 OFFSET_X_Y = (0.37, 0.53)
@@ -13,8 +13,8 @@ OFFSET_X_Y = (0.37, 0.53)
 
 def test_blur_face():
     depthmap_dir = str(TOOLKIT_DIR / 'huawei_p40pro')
-    depthmap_fname = 'depth_dog_1622182020448_100_234.depth'
-    rgb_fname = 'rgb_dog_1622182020448_100_234.jpg'
+    depthmap_fname = 'depth_dog_1622182020448_100_282.depth'
+    rgb_fname = 'rgb_dog_1622182020448_100_282.jpg'
     calibration_file = str(TOOLKIT_DIR / 'huawei_p40pro' / 'camera_calibration.txt')
     dmap = Depthmap.create_from_file(depthmap_dir, depthmap_fname, rgb_fname, calibration_file)
 
@@ -23,32 +23,29 @@ def test_blur_face():
     mask = dmap.detect_child(floor)
     highest = dmap.get_highest_point(mask)  # 3D
 
-    # Render the visualisations
-    output_unblurred = np.zeros((dmap.width, dmap.height * SUBPLOT_COUNT, 3))
-    for x in range(dmap.width):
-        for y in range(dmap.height):
-            render_pixel(output_unblurred, x, y, floor, mask, dmap)
+    # Render the color data
+    output_unblurred = np.zeros((dmap.width, dmap.height, 3))
+    render_rgb(output_unblurred, 0, dmap)
 
     # Blur
-    output_blurred = blur_face(output_unblurred, highest, dmap)
+    output_blurred = blur_face(output_unblurred, 0, highest, dmap)
 
     # Assert some pixels in whole image change (image not same)
-    all_count = dmap.width * dmap.height * SUBPLOT_COUNT
+    all_count = dmap.width * dmap.height
     count = np.count_nonzero(output_unblurred - output_blurred) / 3
     ratio_blurred = count / all_count
-    assert 0.003 < ratio_blurred < 0.9
+    assert 0.01 < ratio_blurred < 0.9
 
     # Assert that blurred around object
-    offset = SUBPLOT_RGB * dmap.height
     object_x = int(dmap.width * OFFSET_X_Y[0])
-    object_y = offset + int(dmap.height * (1.0 - OFFSET_X_Y[1]))
+    object_y = int(dmap.height * (1.0 - OFFSET_X_Y[1]))
     slice_x = slice(object_x - 2, object_x + 2)
     slice_y = slice(object_y - 2, object_y + 2)
     assert (output_unblurred[slice_x, slice_y] != output_blurred[slice_x, slice_y]).any()
 
     # Assert that NOT blurred around corner
     corner_x = 0
-    corner_y = offset
+    corner_y = 0
     slice_x = slice(corner_x, corner_x + 4)
     slice_y = slice(corner_y, corner_y + 4)
     assert (output_unblurred[slice_x, slice_y] == output_blurred[slice_x, slice_y]).all()

--- a/src/common/depthmap_toolkit/visualisation.py
+++ b/src/common/depthmap_toolkit/visualisation.py
@@ -87,7 +87,6 @@ def render_depth(output: np.array,
 def render_normal(output: np.array,
                   subplot: int,
                   dmap: Depthmap):
-
     for x in range(dmap.width):
         for y in range(dmap.height):
             normal = dmap.calculate_normal_vector(x, y)

--- a/src/common/depthmap_toolkit/visualisation.py
+++ b/src/common/depthmap_toolkit/visualisation.py
@@ -22,7 +22,7 @@ SUBPLOT_RGB = 4
 SUBPLOT_COUNT = 5
 
 
-def blur_face(data: np.array, highest: list, dmap: Depthmap) -> np.array:
+def blur_face(data: np.array, subplot: int, highest: list, dmap: Depthmap) -> np.array:
     """Faceblur of the detected standing child.
 
     It uses the highest point of the child and blur all pixels in distance less than CHILD_HEAD_HEIGHT_IN_METERS.
@@ -52,78 +52,101 @@ def blur_face(data: np.array, highest: list, dmap: Depthmap) -> np.array:
                 for ty in range(y - step, y + step):
                     if not (0 < tx < dmap.width and 0 < ty < dmap.height):
                         continue
-                    index = SUBPLOT_RGB * dmap.height + dmap.height - ty - 1
+                    index = subplot * dmap.height + dmap.height - ty - 1
                     pixel = pixel + data[tx][index][0]
                     count = count + 1
-            index = SUBPLOT_RGB * dmap.height + dmap.height - y - 1
+            index = subplot * dmap.height + dmap.height - y - 1
             output[x][index] = pixel / count
 
     return output
 
+def render_confidence(output: np.array,
+                      subplot: int,
+                      dmap: Depthmap):
 
-def render_pixel(output: np.array,
-                 x: int,
-                 y: int,
-                 floor: float,
-                 mask: np.array,
+    for x in range(dmap.width):
+        for y in range(dmap.height):
+            index = subplot * dmap.height + dmap.height - y - 1
+            output[x][index][:] = dmap.parse_confidence(x, y)
+            if output[x][index][0] == 0:
+                output[x][index][:] = 1
+
+
+def render_depth(output: np.array,
+                 subplot: int,
                  dmap: Depthmap):
 
-    # RGB data visualisation
-    if dmap.has_rgb:
-        index = SUBPLOT_RGB * dmap.height + dmap.height - y - 1
-        output[x][index][0] = dmap.rgb_array[y][x][0] / 255.0
-        output[x][index][1] = dmap.rgb_array[y][x][1] / 255.0
-        output[x][index][2] = dmap.rgb_array[y][x][2] / 255.0
+    for x in range(dmap.width):
+        for y in range(dmap.height):
+            depth = dmap.parse_depth(x, y)
+            if not depth:
+                continue
+            index = subplot * dmap.height + dmap.height - y - 1
+            output[x][index] = min(max(0, 1.0 - min(depth / 2.0, 1.0)), 1)
 
-    depth = dmap.parse_depth(x, y)
-    if not depth:
-        return
 
-    # convert ToF coordinates into RGB coordinates
-    vec = dmap.convert_2d_to_3d(1, x, y, depth)
-    vec = dmap.convert_3d_to_2d(0, vec[0], vec[1], vec[2])
+def render_normal(output: np.array,
+                  subplot: int,
+                  dmap: Depthmap):
 
-    # depth data visualisation (scaled to be visible)
-    index = SUBPLOT_DEPTH * dmap.height + dmap.height - y - 1
-    output[x][index] = 1.0 - min(depth / 2.0, 1.0)
+    for x in range(dmap.width):
+        for y in range(dmap.height):
+            normal = dmap.calculate_normal_vector(x, y)
+            index = subplot * dmap.height + dmap.height - y - 1
+            output[x][index][0] = abs(normal[0])
+            output[x][index][1] = abs(normal[1])
+            output[x][index][2] = abs(normal[2])
 
-    # normal vector visualisation
-    normal = dmap.calculate_normal_vector(x, y)
-    index = SUBPLOT_NORMAL * dmap.height + dmap.height - y - 1
-    output[x][index][0] = abs(normal[0])
-    output[x][index][1] = abs(normal[1])
-    output[x][index][2] = abs(normal[2])
 
-    # segmentation visualisation
-    point = dmap.convert_2d_to_3d_oriented(1, x, y, depth)
-    horizontal = (point[1] % PATTERN_LENGTH_IN_METERS) / PATTERN_LENGTH_IN_METERS
-    vertical_x = (point[0] % PATTERN_LENGTH_IN_METERS) / PATTERN_LENGTH_IN_METERS
-    vertical_z = (point[2] % PATTERN_LENGTH_IN_METERS) / PATTERN_LENGTH_IN_METERS
-    vertical = (vertical_x + vertical_z) / 2.0
-    index = SUBPLOT_SEGMENTATION * dmap.height + dmap.height - y - 1
-    if mask[x][y] == MASK_CHILD:
-        output[x][index][0] = horizontal / (depth * depth)
-        output[x][index][1] = horizontal / (depth * depth)
-    elif abs(normal[1]) < 0.5:
-        output[x][index][0] = horizontal / (depth * depth)
-    elif abs(normal[1]) > 0.5:
-        if abs(point[1] - floor) < 0.1:
-            output[x][index][2] = vertical / (depth * depth)
-        else:
-            output[x][index][1] = vertical / (depth * depth)
+def render_rgb(output: np.array,
+               subplot: int,
+               dmap: Depthmap):
 
-    # confidence value visualisation
-    index = SUBPLOT_CONFIDENCE * dmap.height + dmap.height - y - 1
-    output[x][index][:] = dmap.parse_confidence(x, y)
-    if output[x][index][0] == 0:
-        output[x][index][:] = 1
+    for x in range(dmap.width):
+        for y in range(dmap.height):
+            index = subplot * dmap.height + dmap.height - y - 1
+            output[x][index][0] = dmap.rgb_array[y][x][0] / 255.0
+            output[x][index][1] = dmap.rgb_array[y][x][1] / 255.0
+            output[x][index][2] = dmap.rgb_array[y][x][2] / 255.0
 
-    # ensure pixel clipping
-    for i in range(SUBPLOT_COUNT):
-        index = i * dmap.height + dmap.height - y - 1
-        output[x][index][0] = min(max(0, output[x][index][0]), 1)
-        output[x][index][1] = min(max(0, output[x][index][1]), 1)
-        output[x][index][2] = min(max(0, output[x][index][2]), 1)
+
+def render_segmentation(output: np.array,
+                        subplot: int,
+                        floor: float,
+                        mask: np.array,
+                        dmap: Depthmap):
+
+    for x in range(dmap.width):
+        for y in range(dmap.height):
+
+            # get depth value
+            depth = dmap.parse_depth(x, y)
+            if not depth:
+                continue
+
+            # segmentation visualisation
+            normal = dmap.calculate_normal_vector(x, y)
+            point = dmap.convert_2d_to_3d_oriented(1, x, y, depth)
+            horizontal = (point[1] % PATTERN_LENGTH_IN_METERS) / PATTERN_LENGTH_IN_METERS
+            vertical_x = (point[0] % PATTERN_LENGTH_IN_METERS) / PATTERN_LENGTH_IN_METERS
+            vertical_z = (point[2] % PATTERN_LENGTH_IN_METERS) / PATTERN_LENGTH_IN_METERS
+            vertical = (vertical_x + vertical_z) / 2.0
+            index = subplot * dmap.height + dmap.height - y - 1
+            if mask[x][y] == MASK_CHILD:
+                output[x][index][0] = horizontal / (depth * depth)
+                output[x][index][1] = horizontal / (depth * depth)
+            elif abs(normal[1]) < 0.5:
+                output[x][index][0] = horizontal / (depth * depth)
+            elif abs(normal[1]) > 0.5:
+                if abs(point[1] - floor) < 0.1:
+                    output[x][index][2] = vertical / (depth * depth)
+                else:
+                    output[x][index][1] = vertical / (depth * depth)
+
+            # ensure pixel clipping
+            output[x][index][0] = min(max(0, output[x][index][0]), 1)
+            output[x][index][1] = min(max(0, output[x][index][1]), 1)
+            output[x][index][2] = min(max(0, output[x][index][2]), 1)
 
 
 def render_plot(dmap: Depthmap) -> np.array:
@@ -134,11 +157,13 @@ def render_plot(dmap: Depthmap) -> np.array:
 
     # render the visualisations
     output = np.zeros((dmap.width, dmap.height * SUBPLOT_COUNT, 3))
-    for x in range(dmap.width):
-        for y in range(dmap.height):
-            render_pixel(output, x, y, floor, mask, dmap)
+    render_depth(output, SUBPLOT_DEPTH, dmap)
+    render_normal(output, SUBPLOT_NORMAL, dmap)
+    render_segmentation(output, SUBPLOT_SEGMENTATION, floor, mask, dmap)
+    render_confidence(output, SUBPLOT_CONFIDENCE, dmap)
     if dmap.has_rgb:
-        output = blur_face(output, highest, dmap)
+        render_rgb(output, SUBPLOT_RGB, dmap)
+        output = blur_face(output, SUBPLOT_RGB, highest, dmap)
 
     logging.info('height=%fm', highest[1] - floor)
     return output

--- a/src/common/depthmap_toolkit/visualisation.py
+++ b/src/common/depthmap_toolkit/visualisation.py
@@ -60,6 +60,7 @@ def blur_face(data: np.array, subplot: int, highest: list, dmap: Depthmap) -> np
 
     return output
 
+
 def render_confidence(output: np.array,
                       subplot: int,
                       dmap: Depthmap):

--- a/src/common/depthmap_toolkit/visualisation.py
+++ b/src/common/depthmap_toolkit/visualisation.py
@@ -112,7 +112,6 @@ def render_segmentation(output: np.array,
                         floor: float,
                         mask: np.array,
                         dmap: Depthmap):
-
     for x in range(dmap.width):
         for y in range(dmap.height):
 

--- a/src/common/depthmap_toolkit/visualisation.py
+++ b/src/common/depthmap_toolkit/visualisation.py
@@ -64,7 +64,6 @@ def blur_face(data: np.array, subplot: int, highest: list, dmap: Depthmap) -> np
 def render_confidence(output: np.array,
                       subplot: int,
                       dmap: Depthmap):
-
     for x in range(dmap.width):
         for y in range(dmap.height):
             index = subplot * dmap.height + dmap.height - y - 1

--- a/src/common/depthmap_toolkit/visualisation.py
+++ b/src/common/depthmap_toolkit/visualisation.py
@@ -99,7 +99,6 @@ def render_normal(output: np.array,
 def render_rgb(output: np.array,
                subplot: int,
                dmap: Depthmap):
-
     for x in range(dmap.width):
         for y in range(dmap.height):
             index = subplot * dmap.height + dmap.height - y - 1

--- a/src/common/depthmap_toolkit/visualisation.py
+++ b/src/common/depthmap_toolkit/visualisation.py
@@ -75,7 +75,6 @@ def render_confidence(output: np.array,
 def render_depth(output: np.array,
                  subplot: int,
                  dmap: Depthmap):
-
     for x in range(dmap.width):
         for y in range(dmap.height):
             depth = dmap.parse_depth(x, y)


### PR DESCRIPTION
# Description

This refactor enables to use the visualisations in other scripts. E.g. to get normal map call:
```
    output = np.zeros((dmap.width, dmap.height, 3))
    render_normal(output, 0, dmap)
```