### PR TITLE
Move test_copy_dir() to cgmcore/

### DIFF
--- a/src/common/cgmcore/file_utils.py
+++ b/src/common/cgmcore/file_utils.py
@@ -1,0 +1,23 @@
+import logging
+import logging.config
+from pathlib import Path
+import shutil
+
+logging.basicConfig(level=logging.INFO,
+                    format='%(asctime)s - %(levelname)s - %(message)s - %(pathname)s: line %(lineno)d')
+
+
+def copy_dir(src: Path, tgt: Path, glob_pattern: str, should_touch_init: bool = False):
+    logging.info("Creating temp folder")
+    if tgt.exists():
+        shutil.rmtree(tgt)
+    tgt.mkdir(parents=True, exist_ok=True)
+    if should_touch_init:
+        (tgt / '__init__.py').touch(exist_ok=False)
+
+    paths_to_copy = list(src.glob(glob_pattern))
+    logging.info(f"Copying to {tgt} the following files: {str(paths_to_copy)}")
+    for p in paths_to_copy:
+        destpath = tgt / p.relative_to(src)
+        destpath.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy(p, destpath)

--- a/src/common/cgmcore/tests/test_file_utils.py
+++ b/src/common/cgmcore/tests/test_file_utils.py
@@ -1,0 +1,54 @@
+import shutil
+from pathlib import Path
+import pytest
+import sys
+
+CWD = Path(__file__).resolve()
+
+sys.path.append(str(CWD.parents[1]))  # cgmcore/ dir
+
+from file_utils import copy_dir  # noqa: E402
+
+REPO_DIR = str(CWD.parents[4].absolute())
+
+
+@pytest.fixture
+def temp_common_dir():
+    temp_common_dir = Path(CWD.parent / "temp_common")
+    yield temp_common_dir
+    try:
+        shutil.rmtree(temp_common_dir)
+    except OSError:
+        pass
+
+
+@pytest.fixture
+def empty_dir():
+    empty_dir = Path(CWD.parent / "copy_empty")
+    empty_dir.mkdir(parents=True, exist_ok=True)
+    yield empty_dir
+    try:
+        shutil.rmtree(empty_dir)
+    except OSError:
+        pass
+
+
+@pytest.fixture
+def temp_empty_dir():
+    temp_empty_dir = Path(CWD.parent / "temp_empty_dir")
+    yield temp_empty_dir
+    try:
+        shutil.rmtree(temp_empty_dir)
+    except OSError:
+        pass
+
+
+def test_copy_dir(temp_common_dir):
+    common_dir_path = Path(REPO_DIR + "/src/common")
+    copy_dir(src=common_dir_path, tgt=temp_common_dir, glob_pattern='*/*.py', should_touch_init=True)
+    assert temp_common_dir.is_dir(), 'The temp_common_dir does not exist. Did copy_dir fail?'
+
+
+def test_copy_empty_dir(empty_dir, temp_empty_dir):
+    copy_dir(src=empty_dir, tgt=temp_empty_dir, glob_pattern='*/*.py', should_touch_init=False)
+    assert temp_empty_dir.is_dir(), 'The temp_empty_dir does not exist. Did copy_dir fail for an empty directory?'

--- a/src/common/evaluation/QA/eval_depthmap_models/src/test_evaluate.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/test_evaluate.py
@@ -7,54 +7,12 @@ import pandas as pd
 
 CWD = Path(__file__).resolve()
 
-sys.path.append(str(CWD.parents[4]))
+sys.path.append(str(CWD.parents[4]))  # common/ dir
 
 REPO_DIR = str(CWD.parents[6].absolute())
 
-from evaluation.QA.eval_depthmap_models.src.evaluate import (copy_dir, prepare_sample_dataset,  # noqa: E402
+from evaluation.QA.eval_depthmap_models.src.evaluate import (prepare_sample_dataset,  # noqa: E402
                                                              tf_load_pickle)
-
-
-@pytest.fixture
-def temp_common_dir():
-    temp_common_dir = Path(CWD.parent / "temp_common")
-    yield temp_common_dir
-    try:
-        shutil.rmtree(temp_common_dir)
-    except OSError:
-        pass
-
-
-@pytest.fixture
-def empty_dir():
-    empty_dir = Path(CWD.parent / "copy_empty")
-    empty_dir.mkdir(parents=True, exist_ok=True)
-    yield empty_dir
-    try:
-        shutil.rmtree(empty_dir)
-    except OSError:
-        pass
-
-
-@pytest.fixture
-def temp_empty_dir():
-    temp_empty_dir = Path(CWD.parent / "temp_empty_dir")
-    yield temp_empty_dir
-    try:
-        shutil.rmtree(temp_empty_dir)
-    except OSError:
-        pass
-
-
-def test_copy_dir(temp_common_dir):
-    common_dir_path = Path(REPO_DIR + "/src/common")
-    copy_dir(src=common_dir_path, tgt=temp_common_dir, glob_pattern='*/*.py', should_touch_init=True)
-    assert temp_common_dir.is_dir(), 'The temp_common_dir does not exist. Did copy_dir fail?'
-
-
-def test_copy_empty_dir(empty_dir, temp_empty_dir):
-    copy_dir(src=empty_dir, tgt=temp_empty_dir, glob_pattern='*/*.py', should_touch_init=False)
-    assert temp_empty_dir.is_dir(), 'The temp_empty_dir does not exist. Did copy_dir fail for an empty directory?'
 
 
 def test_prepare_sample_dataset():

--- a/src/common/evaluation/QA/eval_depthmap_models/src/test_evaluate.py
+++ b/src/common/evaluation/QA/eval_depthmap_models/src/test_evaluate.py
@@ -1,5 +1,4 @@
 import sys
-import shutil
 from pathlib import Path
 import pytest
 

--- a/src/common/evaluation/tests/test_uncertainty_utils.py
+++ b/src/common/evaluation/tests/test_uncertainty_utils.py
@@ -4,7 +4,7 @@ import sys
 import numpy as np
 import tensorflow as tf
 
-sys.path.append(str(Path(__file__).parents[2]))  # common
+sys.path.append(str(Path(__file__).parents[2]))  # common/ dir
 
 from evaluation.uncertainty_utils import _predict, _calculate_std  # noqa: E402
 from model_utils.model_plaincnn import create_cnn  # noqa: E402

--- a/src/common/evaluation/tests/test_utils.py
+++ b/src/common/evaluation/tests/test_utils.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
-sys.path.append(str(Path(__file__).parents[2]))  # common
+sys.path.append(str(Path(__file__).parents[2]))  # common/ dir
 
 from evaluation.eval_utilities import (COLUMN_NAME_GOODBAD,  # noqa: E402
                                        calculate_percentage_confusion_matrix,


### PR DESCRIPTION
**Motivation:** `copy_dir` is used not only in `evaluate.py` but also outside. The location of the function and the test seem too specific.

**Solution:** Move the function to src/common/cgmcore/file_util.py