### PR TITLE
Use cluster with different GPU type: NVIDIA M60

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -20,9 +20,9 @@ jobs:
       id: cache-venv
       with:
         path: ./.venv/
-        key: ${{ runner.os }}-cache-v2-${{ hashFiles('requirements.txt') }}
+        key: ${{ runner.os }}-cache-v3-${{ hashFiles('requirements.txt') }}
         restore-keys: |
-          ${{ runner.os }}-cache-v2-
+          ${{ runner.os }}-cache-v3-
     - run: python -m venv ./.venv && . ./.venv/bin/activate &&
            python -m pip install --upgrade pip==20.2 && pip install setuptools==50.3.2 wheel==0.36.2 && pip install -r requirements.txt
       if: steps.cache-venv.outputs.cache-hit != 'true'

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/src/config.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/src/config.py
@@ -19,7 +19,7 @@ CONFIG = Bunch(dict(
     USE_DROPOUT=False,
     USE_WANDB=False,
     USE_MULTIGPU=False,
-    CLUSTER_NAME='gpu-cluster-M60',
+    CLUSTER_NAME='gpu-cluster',
 
     # Parameters for dataset generation.
     TARGET_INDEXES=[0],  # 0 is height, 1 is weight.

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/src/config.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/src/config.py
@@ -19,6 +19,7 @@ CONFIG = Bunch(dict(
     USE_DROPOUT=False,
     USE_WANDB=False,
     USE_MULTIGPU=False,
+    CLUSTER_NAME='gpu-cluster-M60',
 
     # Parameters for dataset generation.
     TARGET_INDEXES=[0],  # 0 is height, 1 is weight.

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/src/config_deep_ensemble.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/src/config_deep_ensemble.py
@@ -19,6 +19,7 @@ CONFIG = Bunch(dict(
     USE_DROPOUT=False,
     USE_WANDB=False,
     USE_MULTIGPU=False,
+    CLUSTER_NAME='gpu-cluster',
 
     # Parameters for dataset generation.
     TARGET_INDEXES=[0],  # 0 is height, 1 is weight.

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/src/config_weight.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/src/config_weight.py
@@ -19,6 +19,7 @@ CONFIG = Bunch(dict(
     USE_DROPOUT=False,
     USE_WANDB=False,
     USE_MULTIGPU=False,
+    CLUSTER_NAME='gpu-cluster',
 
     # Parameters for dataset generation.
     TARGET_INDEXES=[1],  # 0 is height, 1 is weight.

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/train_notebook.ipynb
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/train_notebook.ipynb
@@ -56,8 +56,8 @@
    "outputs": [],
    "source": [
     "dataset_name = \"anon-depthmap-95k\"  # \"anon-depthmap-mini\"\n",
-    "experiment_name = \"q3-depthmap-plaincnn-height-95k\"\n",
-    "tags = {}"
+    "experiment_name = \"training-junkyard-multigpu\"\n",
+    "tags = {'GPU': '1xM60'}"
    ]
   },
   {
@@ -150,7 +150,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cluster_name = \"multigpu-cluster\" if CONFIG.USE_MULTIGPU else \"gpu-cluster\"\n",
+    "cluster_name = CONFIG.CLUSTER_NAME\n",
     "\n",
     "# Compute cluster exists. Just connect to it.\n",
     "try:\n",

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/train_notebook.ipynb
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmap-plaincnn-height/train_notebook.ipynb
@@ -56,8 +56,8 @@
    "outputs": [],
    "source": [
     "dataset_name = \"anon-depthmap-95k\"  # \"anon-depthmap-mini\"\n",
-    "experiment_name = \"training-junkyard-multigpu\"\n",
-    "tags = {'GPU': '1xM60'}"
+    "experiment_name = \"q3-depthmap-plaincnn-height-95k\"\n",
+    "tags = {}"
    ]
   },
   {

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/config.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/config.py
@@ -35,6 +35,7 @@ CONFIG = Bunch(dict(
     USE_DROPOUT=False,
     USE_ONE_CYCLE=False,
     USE_MULTIGPU=False,
+    CLUSTER_NAME='gpu-cluster',
 
     PRETRAINED_RUN="q3-depthmap-plaincnn-height-95k_1610709869_2e00a6ef",  # Run4 (baseline: min(val_mae)=1.78cm)
 

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/config_weight.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/src/config_weight.py
@@ -35,6 +35,7 @@ CONFIG = Bunch(dict(
     USE_DROPOUT=False,
     USE_ONE_CYCLE=False,
     USE_MULTIGPU=False,
+    CLUSTER_NAME='gpu-cluster',
 
     PRETRAINED_RUN='q4-depthmap-plaincnn-weight-95k_1616424204_63e3c1b8',  # Run 5
 

--- a/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/train_notebook.ipynb
+++ b/src/models/CNNDepthMap/CNNDepthMap-height/q3-depthmapmultiartifactlatefusion-plaincnn-height/train_notebook.ipynb
@@ -150,7 +150,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cluster_name = \"multigpu-cluster\" if CONFIG.USE_MULTIGPU else \"gpu-cluster\"\n",
+    "cluster_name = CONFIG.CLUSTER_NAME\n",
     "\n",
     "# Compute cluster exists. Just connect to it.\n",
     "try:\n",

--- a/src/models/CNNDepthMap/CNNDepthMap-multitask/q4-depthmap-plaincnn-multitask/src/config.py
+++ b/src/models/CNNDepthMap/CNNDepthMap-multitask/q4-depthmap-plaincnn-multitask/src/config.py
@@ -17,6 +17,7 @@ CONFIG = Bunch(dict(
     LEARNING_RATE=0.0007,
     USE_ONE_CYCLE=True,
     USE_MULTIGPU=False,
+    CLUSTER_NAME='gpu-cluster',
 
     # Parameters for dataset generation.
     TARGET_INDEXES=[0, 1],  # 0 is height, 1 is weight.

--- a/src/models/CNNDepthMap/CNNDepthMap-multitask/q4-depthmap-plaincnn-multitask/train_notebook.ipynb
+++ b/src/models/CNNDepthMap/CNNDepthMap-multitask/q4-depthmap-plaincnn-multitask/train_notebook.ipynb
@@ -150,7 +150,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cluster_name = \"multigpu-cluster\" if CONFIG.USE_MULTIGPU else \"gpu-cluster\"\n",
+    "cluster_name = CONFIG.CLUSTER_NAME\n",
     "\n",
     "# Compute cluster exists. Just connect to it.\n",
     "try:\n",

--- a/src/models/CNNRGB/CNNRGB-standing_laying/q4-rgb-standing-laying/src/sl_config.py
+++ b/src/models/CNNRGB/CNNRGB-standing_laying/q4-rgb-standing-laying/src/sl_config.py
@@ -17,4 +17,5 @@ CONFIG = Bunch(dict(
     LEARNING_RATE=1e-5,
     TUNE_EPOCHS=10,
     USE_MULTIGPU=False,
+    CLUSTER_NAME='gpu-cluster',
 ))

--- a/src/models/CNNRGB/CNNRGB-standing_laying/q4-rgb-standing-laying/train_notebook.ipynb
+++ b/src/models/CNNRGB/CNNRGB-standing_laying/q4-rgb-standing-laying/train_notebook.ipynb
@@ -166,7 +166,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cluster_name = \"multigpu-cluster\" if CONFIG.USE_MULTIGPU else \"gpu-cluster\"\n",
+    "cluster_name = CONFIG.CLUSTER_NAME\n",
     "\n",
     "# Compute cluster exists. Just connect to it.\n",
     "try:\n",


### PR DESCRIPTION
**Changes:**
- introduce config parameter CLUSTER_NAME in training configs
- use CLUSTER_NAME in train_notebooks
- Re-do github actions virtualenv creation (and cache it)

**Time Measurements**

| Run       | Comment        | Epoch duration  |
| -------- |:-------------:| -----:|
| Run11     | K80, BS=64, baseline                  |  837s | 
| [Run 16](https://ml.azure.com/experiments/id/4d4b47ee-b56c-44ca-8966-1a8d77201ece/runs/training-junkyard-multigpu_1625831777_496c6dc5?wsid=/subscriptions/9b5bbfae-d5d1-4aae-a2ca-75159c0c887d/resourceGroups/cgm-ml-prod-we-rg/providers/Microsoft.MachineLearningServices/workspaces/cgm-ml-prod-we-azml&tid=3a27c573-ec1a-4734-9cd3-3208af51794b)   | M60, BS64, baseline           | 448s | 
| Run17     | M60, BS=128, baseline                  |  452s  | 
| Run15 und Run19     | K60, BS=256, baseline                  |  failed twice: OOM | 

* [related Experiment with Runs](https://ml.azure.com/experiments/id/4d4b47ee-b56c-44ca-8966-1a8d77201ece?wsid=/subscriptions/9b5bbfae-d5d1-4aae-a2ca-75159c0c887d/resourceGroups/cgm-ml-prod-we-rg/providers/Microsoft.MachineLearningServices/workspaces/cgm-ml-prod-we-azml&tid=3a27c573-ec1a-4734-9cd3-3208af51794b)
* See time measurements done before for multi-gpu here: https://github.com/Welthungerhilfe/cgm-ml/pull/385

**Result:** 
- M60 is 1.87 times as fast as a K80
- but M60 has only 2x8GB of memory (K80 has 2x12GB)
- [M60 is a newer(=better) generation architecture](https://www.quora.com/What-are-the-major-differences-between-the-Nvidia-Tesla-M60-and-K80) ([comparison](https://en.wikipedia.org/wiki/Nvidia_Tesla))