### PR TITLE
Refactor to re-use CV-based image segmentation and normals

### DIFF
--- a/src/common/depthmap_toolkit/EDA_RGBD_segmentationCV.ipynb
+++ b/src/common/depthmap_toolkit/EDA_RGBD_segmentationCV.ipynb
@@ -1,0 +1,320 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%reload_ext autoreload\n",
+    "%autoreload 2\n",
+    "\n",
+    "from copy import copy\n",
+    "import os\n",
+    "from pathlib import Path\n",
+    "from pathlib import Path\n",
+    "import pickle\n",
+    "\n",
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt\n",
+    "from bunch import Bunch\n",
+    "import numpy as np\n",
+    "import tensorflow as tf\n",
+    "import glob2 as glob\n",
+    "from azureml.core import Experiment, Workspace\n",
+    "from azureml.core.run import Run\n",
+    "\n",
+    "from visualisation import render_plot\n",
+    "from exporter import export_obj\n",
+    "from constants import MASK_CHILD\n",
+    "from depthmap import Depthmap\n",
+    "\n",
+    "sys.path.append(str(REPO_DIR /'src'))\n",
+    "\n",
+    "from common.model_utils.utils import download_dataset, get_dataset_path, AzureLogCallback, create_tensorboard_callback, get_optimizer, setup_wandb\n",
+    "from common.model_utils.preprocessing import filter_blacklisted_qrcodes, preprocess_depthmap, preprocess_targets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "REPO_DIR = Path('/Users/markus/Development/cgm/cgm-ml')\n",
+    "TOOLKIT_DIR = Path(os.getcwd()).absolute()\n",
+    "print(TOOLKIT_DIR)\n",
+    "calibration_file = TOOLKIT_DIR / 'tests' / 'huawei_p40pro' / 'camera_calibration.txt'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DATASET_MODE_DOWNLOAD = \"dataset_mode_download\"\n",
+    "DATASET_MODE_MOUNT = \"dataset_mode_mount\"\n",
+    "\n",
+    "CONFIG = Bunch(dict(\n",
+    "    DATASET_MODE=DATASET_MODE_DOWNLOAD,\n",
+    "    DATASET_NAME=\"anon-rgbd-5kscans\",\n",
+    "    DATASET_NAME_LOCAL=\"anon-rgbd-5kscans-mini\",  # 20 qrcodes\n",
+    "    SPLIT_SEED=0,\n",
+    "    IMAGE_TARGET_HEIGHT=240,\n",
+    "    IMAGE_TARGET_WIDTH=180,\n",
+    "    CODES=['100', '101', '102', '200', '201', '202'],\n",
+    "    NORMALIZATION_VALUE=7.5,\n",
+    "    TARGET_INDEXES=[0],  # 0 is height, 1 is weight.\n",
+    "))\n",
+    "\n",
+    "\n",
+    "def tf_load_pickle(path, max_value):\n",
+    "    def py_load_pickle(path, max_value):\n",
+    "        rgbd, targets = pickle.load(open(path.numpy(), \"rb\"))\n",
+    "        rgb = rgbd[0]  # shape: (240, 180, 3)\n",
+    "        depthmap = rgbd[1]  # shape: (240, 180)\n",
+    "\n",
+    "        rgb = preprocess_depthmap(rgb)\n",
+    "        rgb = rgb / 255.\n",
+    "\n",
+    "        depthmap = preprocess_depthmap(depthmap)\n",
+    "        depthmap = depthmap / max_value\n",
+    "        depthmap = tf.expand_dims(depthmap, -1)  # shape: (240, 180, 1)\n",
+    "        rgbd = tf.concat([rgb, depthmap], axis=2)\n",
+    "        rgbd = tf.image.resize(rgbd, (CONFIG.IMAGE_TARGET_HEIGHT, CONFIG.IMAGE_TARGET_WIDTH))\n",
+    "        targets = preprocess_targets(targets, CONFIG.TARGET_INDEXES)\n",
+    "        return rgbd, targets\n",
+    "\n",
+    "    rgbd, targets = tf.py_function(py_load_pickle, [path, max_value], [tf.float32, tf.float32])\n",
+    "    rgbd.set_shape((CONFIG.IMAGE_TARGET_HEIGHT, CONFIG.IMAGE_TARGET_WIDTH, 4))\n",
+    "    targets.set_shape((len(CONFIG.TARGET_INDEXES,)))\n",
+    "    return rgbd, targets\n",
+    "\n",
+    "def get_depthmap_files(paths):\n",
+    "    pickle_paths = []\n",
+    "    for path in paths:\n",
+    "        for code in CONFIG.CODES:\n",
+    "            pickle_paths.extend(glob.glob(os.path.join(path, code, \"*.p\")))\n",
+    "    return pickle_paths"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run = Run.get_context()\n",
+    "DATA_DIR = REPO_DIR / 'data' if run.id.startswith(\"OfflineRun\") else Path(\".\")\n",
+    "\n",
+    "# Offline run. Download the sample dataset and run locally. Still push results to Azure.\n",
+    "if run.id.startswith(\"OfflineRun\"):\n",
+    "    workspace = Workspace.from_config()\n",
+    "    experiment = Experiment(workspace, \"training-junkyard\")\n",
+    "    run = experiment.start_logging(outputs=None, snapshot_directory=None)\n",
+    "\n",
+    "    dataset_name = CONFIG.DATASET_NAME_LOCAL\n",
+    "    dataset_path = get_dataset_path(DATA_DIR, dataset_name)\n",
+    "    download_dataset(workspace, dataset_name, dataset_path)\n",
+    "else:\n",
+    "    assert False\n",
+    "\n",
+    "dataset_path = os.path.join(dataset_path, \"qrcode\")\n",
+    "print(f'Dataset path: {dataset_path}')\n",
+    "print('Getting QR-code paths...')\n",
+    "qrcode_paths = glob.glob(os.path.join(dataset_path, \"*\"))\n",
+    "print(f'qrcode_paths: {len(qrcode_paths)}')\n",
+    "assert len(qrcode_paths) != 0\n",
+    "\n",
+    "qrcode_paths = glob.glob(os.path.join(dataset_path, \"*\"))\n",
+    "print(f'qrcode_paths: {len(qrcode_paths)}')\n",
+    "assert len(qrcode_paths) != 0\n",
+    "\n",
+    "paths_training = get_depthmap_files(qrcode_paths)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "path = paths_training[0]\n",
+    "path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rgbd, target = tf_load_pickle(path, CONFIG.NORMALIZATION_VALUE)\n",
+    "rgbd_arr = rgbd.numpy()\n",
+    "bgr = rgbd_arr[:, :, :3]\n",
+    "rgb = bgr[:, :, ::-1]\n",
+    "\n",
+    "depthmap = rgbd_arr[:, :, -1]\n",
+    "depthmap_rescaled = depthmap / depthmap.max() * 255"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dmap = Depthmap.create_from_array(depthmap_arr=depthmap, rgb_arr=rgb, calibration_file=str(calibration_file))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "floor = dmap.get_floor_level()\n",
+    "mask = dmap.detect_child(floor)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mask.min(), mask.max()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.imshow(mask, cmap='gray');"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mask_child = (mask==MASK_CHILD).astype(np.int)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.imshow(mask_child, cmap='gray');"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.imshow(rgb);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.imshow(depthmap, cmap='gray');"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.imshow(depthmap_rescaled, cmap='gray');"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(rgb.shape, depthmap.shape)\n",
+    "rgd = copy(rgb)\n",
+    "rgd[:,:,-1] = depthmap_rescaled\n",
+    "plt.imshow(rgd);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "file_extension": ".py",
+  "interpreter": {
+   "hash": "e88cacac4a4e81780274e5b67662f71286bfdfe71b49b67699dc84b91a2b06f4"
+  },
+  "kernel_info": {
+   "name": "python3"
+  },
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3.7.5 64-bit ('env_p_3': virtualenvwrapper)"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.5"
+  },
+  "mimetype": "text/x-python",
+  "name": "python",
+  "npconvert_exporter": "python",
+  "nteract": {
+   "version": "nteract-front-end@1.0.0"
+  },
+  "pygments_lexer": "ipython3",
+  "version": 3
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/src/common/depthmap_toolkit/EDA_RGBD_segmentationCV.ipynb
+++ b/src/common/depthmap_toolkit/EDA_RGBD_segmentationCV.ipynb
@@ -29,6 +29,7 @@
     "from constants import MASK_CHILD\n",
     "from depthmap import Depthmap\n",
     "\n",
+    "REPO_DIR = Path('/Users/markus/Development/cgm/cgm-ml')\n",
     "sys.path.append(str(REPO_DIR /'src'))\n",
     "\n",
     "from common.model_utils.utils import download_dataset, get_dataset_path, AzureLogCallback, create_tensorboard_callback, get_optimizer, setup_wandb\n",
@@ -41,7 +42,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "REPO_DIR = Path('/Users/markus/Development/cgm/cgm-ml')\n",
     "TOOLKIT_DIR = Path(os.getcwd()).absolute()\n",
     "print(TOOLKIT_DIR)\n",
     "calibration_file = TOOLKIT_DIR / 'tests' / 'huawei_p40pro' / 'camera_calibration.txt'"

--- a/src/common/depthmap_toolkit/convertdepth2pcd.py
+++ b/src/common/depthmap_toolkit/convertdepth2pcd.py
@@ -30,9 +30,7 @@ if __name__ == "__main__":
         print('no previous data to delete')
     os.mkdir('export')
     for filename in depth_filenames:
-
         dmap = depthmap.Depthmap.create_from_file(depthmap_dir, filename, 0, calibration_file)
-
         output_filename = f'export/output{filename}.pcd'
         exporter.export_pcd(output_filename, dmap)
 

--- a/src/common/depthmap_toolkit/convertdepth2pcd.py
+++ b/src/common/depthmap_toolkit/convertdepth2pcd.py
@@ -30,7 +30,7 @@ if __name__ == "__main__":
         print('no previous data to delete')
     os.mkdir('export')
     for filename in depth_filenames:
-        dmap = depthmap.Depthmap.create_from_file(depthmap_dir, filename, 0, calibration_file)
+        dmap = depthmap.Depthmap.create_from_zip(depthmap_dir, filename, 0, calibration_file)
         output_filename = f'export/output{filename}.pcd'
         exporter.export_pcd(output_filename, dmap)
 

--- a/src/common/depthmap_toolkit/depthmap.py
+++ b/src/common/depthmap_toolkit/depthmap.py
@@ -237,12 +237,12 @@ class Depthmap:
             for y in range(self.height):
                 depth = self.parse_depth_smoothed(x, y)
                 if not depth:
-                    mask[x][y] = MASK_INVALID
+                    mask[x, y] = MASK_INVALID
                     continue
                 normal = self.calculate_normal_vector(x, y)
                 point = self.convert_2d_to_3d_oriented(1, x, y, depth)
                 if abs(normal[1]) > 0.5 and abs(point[1] - floor) < 0.1:
-                    mask[x][y] = MASK_FLOOR
+                    mask[x, y] = MASK_FLOOR
 
         return mask
 
@@ -254,7 +254,7 @@ class Depthmap:
         mask = self.detect_floor(floor)
         for x in range(self.width):
             for y in range(self.height):
-                if mask[x][y] != 0:
+                if mask[x, y] != 0:
                     continue
                 pixel = [x, y]
                 aabb = [pixel[0], pixel[1], pixel[0], pixel[1]]
@@ -266,7 +266,7 @@ class Depthmap:
                     depth_center = self.depthmap_arr[pixel[0], pixel[1]]
 
                     # Add neighbor points (if there is no floor and they are connected)
-                    if mask[pixel[0]][pixel[1]] == 0:
+                    if mask[pixel[0], pixel[1]] == 0:
                         for direction in dirs:
                             pixel_dir = [pixel[0] + direction[0], pixel[1] + direction[1]]
                             depth_dir = self.depthmap_arr[pixel_dir[0], pixel_dir[1]]
@@ -280,7 +280,7 @@ class Depthmap:
                     aabb[3] = max(pixel[1], aabb[3])
 
                     # Update the mask
-                    mask[pixel[0]][pixel[1]] = current
+                    mask[pixel[0], pixel[1]] = current
 
                 # Check if the object size is valid
                 object_size_pixels = max(aabb[2] - aabb[0], aabb[3] - aabb[1])
@@ -314,7 +314,7 @@ class Depthmap:
         highest = [-sys.maxsize, -sys.maxsize, -sys.maxsize]
         for x in range(self.width):
             for y in range(self.height):
-                if mask[x][y] == MASK_CHILD:
+                if mask[x, y] == MASK_CHILD:
                     depth = self.depthmap_arr[x, y]
                     point = self.convert_2d_to_3d_oriented(1, x, y, depth)
                     if highest[1] < point[1]:

--- a/src/common/depthmap_toolkit/depthmap.py
+++ b/src/common/depthmap_toolkit/depthmap.py
@@ -375,7 +375,7 @@ def convert_3d_to_2d(intrinsics: list, x: float, y: float, depth: float, width: 
     """Convert point in meters into point in pixels
 
         Args:
-            intrinsics of sensor: Tells if this is ToF sensor or RGB sensor
+            intrinsics: is the calibration of the RGB/ToF sensor lenses
             x: X-pos in m
             y: Y-pos in m
             depth: distance from sensor to object at (x, y)

--- a/src/common/depthmap_toolkit/depthmap.py
+++ b/src/common/depthmap_toolkit/depthmap.py
@@ -129,7 +129,30 @@ class Depthmap:
                    rgb_array
                    )
 
+    @classmethod
+    def create_from_array(cls,
+                          depthmap_arr: np.array,
+                          rgb_arr: np.array,
+                          calibration_file: str) -> 'Depthmap':
+        matrix = IDENTITY_MATRIX_4D  # TODO check with Lubos
+        intrinsics = parse_calibration(calibration_file)
 
+        height, width = depthmap_arr.shape
+        data = None  # bytes
+        depth_scale = 0.001
+        max_confidence = 7.0
+        rgb_array = rgb_arr
+
+        return cls(intrinsics,
+                   width,
+                   height,
+                   data,
+                   depthmap_arr,
+                   depth_scale,
+                   max_confidence,
+                   matrix,
+                   rgb_array,
+                   )
 
     def calculate_normal_vector(self, x: float, y: float) -> list:
         """Calculate normal vector of depthmap point based on neighbors"""
@@ -342,7 +365,7 @@ class Depthmap:
         depths = [depth_x_minus, depth_x_plus, depth_y_minus, depth_y_plus, depth_center]
         return sum(depths) / len(depths)
 
-    def convert_3d_to_2d(self, sensor: int, x: float, y: float, depth: float) -> list:
+    def convert_3d_to_2d(self, sensor: int, x: float, y: float, depth: float) -> list:  # TODO unused
         """Convert point in meters into point in pixels
 
         Args:

--- a/src/common/depthmap_toolkit/depthmap.py
+++ b/src/common/depthmap_toolkit/depthmap.py
@@ -199,7 +199,7 @@ class Depthmap:
 
         res = [-res[0], res[1], res[2]]
         if is_google_tango_resolution(self.width, self.height):
-            res = [-res[0], -res[1], -res[2]]
+            res = [-res[0], -res[1], res[2]]
 
         if not self.device_pose:
             logging.warn("Device pose matrix was not provided.")
@@ -352,18 +352,15 @@ class Depthmap:
         """Get average depth value from neighboring pixels"""
         if tx - 1 < 0 or ty - 1 < 0:
             return 0.
-        if tx + 1 >= self.width or ty + 1 >= self.height:
+        if tx + 1 >= self.width - 1 or ty + 1 >= self.height - 1:
             return 0.
 
         # Get all neighbor depths
-        try:
-            depth_center = self.depthmap_arr[tx, ty]
-            depth_x_minus = self.depthmap_arr[tx - 1, ty]
-            depth_x_plus = self.depthmap_arr[tx + 1, ty]
-            depth_y_minus = self.depthmap_arr[tx, ty - 1]
-            depth_y_plus = self.depthmap_arr[tx, ty + 1]
-        except IndexError:
-            return 0.
+        depth_center = self.depthmap_arr[tx, ty]
+        depth_x_minus = self.depthmap_arr[tx - 1, ty]
+        depth_x_plus = self.depthmap_arr[tx + 1, ty]
+        depth_y_minus = self.depthmap_arr[tx, ty - 1]
+        depth_y_plus = self.depthmap_arr[tx, ty + 1]
 
         # Ensure the depth is defined
         if 0 in [depth_center, depth_x_plus, depth_y_minus, depth_y_plus]:

--- a/src/common/depthmap_toolkit/depthmap.py
+++ b/src/common/depthmap_toolkit/depthmap.py
@@ -3,12 +3,12 @@ import logging
 import logging.config
 import math
 import sys
-
+from typing import List, Tuple
 from pathlib import Path
 import statistics
+
 import numpy as np
 from PIL import Image
-from typing import List
 
 from depthmap_utils import (
     matrix_calculate, IDENTITY_MATRIX_4D, parse_numbers, diff, cross, norm, matrix_transform_point)
@@ -77,7 +77,7 @@ class Depthmap:
                          depthmap_dir: str,
                          depthmap_fname: str,
                          rgb_fname: str,
-                         calibration_file: str):
+                         calibration_file: str) -> 'Depthmap':
 
         # read depthmap data
         path = extract_depthmap(depthmap_dir, depthmap_fname)
@@ -205,8 +205,7 @@ class Depthmap:
 
         return mask
 
-    def detect_objects(self, floor: float) -> [np.array, list]:
-
+    def detect_objects(self, floor: float) -> Tuple[np.array, list]:
         # Detect objects/children using seed algorithm
         current = -1
         segments = []
@@ -281,7 +280,7 @@ class Depthmap:
                         highest = point
         return highest
 
-    def parse_confidence(self, tx: int, ty):
+    def parse_confidence(self, tx: int, ty) -> float:
         """Get confidence of the point in scale 0-1"""
         return self.data[(int(ty) * self.width + int(tx)) * 3 + 2] / self.max_confidence
 
@@ -327,7 +326,7 @@ class Depthmap:
         return convert_3d_to_2d(self.intrinsics[sensor], x, y, depth, self.width, self.height)
 
 
-def convert_3d_to_2d(intrinsics: list, x: float, y: float, depth: float, width: int, height: int):
+def convert_3d_to_2d(intrinsics: list, x: float, y: float, depth: float, width: int, height: int) -> list:
     fx = intrinsics[0] * float(width)
     fy = intrinsics[1] * float(height)
     cx = intrinsics[2] * float(width)

--- a/src/common/depthmap_toolkit/depthmap.py
+++ b/src/common/depthmap_toolkit/depthmap.py
@@ -41,9 +41,9 @@ class Depthmap:
         max_confidence (float): Confidence is amount of IR light reflected
                                 (e.g. 0 to 255 in Lenovo, new standard is 0 to 7)
                                 This is actually an int.
-        matrix (List[float]): The device pose (= position and rotation)
+        device_pose (List[float]): The device pose (= position and rotation)
                               The ZIP-file header contains this pose
-                              - `matrix` is a list representation of this pose
+                              - `device_pose` is a list representation of this pose
                               - can be used to project into a different space
         rgb_fpath (str): Path to RGB file (e.g. to the jpg)
         rgb_array (np.array): RGB data
@@ -58,7 +58,7 @@ class Depthmap:
             depthmap_arr: Optional[np.array],
             depth_scale: float,
             max_confidence: float,
-            matrix: List[float],
+            device_pose: List[float],
             rgb_fpath: Path,
             rgb_array: np.array):
         """Constructor
@@ -70,7 +70,7 @@ class Depthmap:
         self.height = height
         self.depth_scale = depth_scale
         self.max_confidence = max_confidence
-        self.matrix = matrix
+        self.device_pose = device_pose
         self.rgb_fpath = rgb_fpath
         self.rgb_array = rgb_array
         assert depthmap_arr is None or data is None
@@ -102,9 +102,9 @@ class Depthmap:
             if len(header) >= 10:
                 position = (float(header[7]), float(header[8]), float(header[9]))
                 rotation = (float(header[3]), float(header[4]), float(header[5]), float(header[6]))
-                matrix = matrix_calculate(position, rotation)
+                device_pose = matrix_calculate(position, rotation)
             else:
-                matrix = IDENTITY_MATRIX_4D
+                device_pose = IDENTITY_MATRIX_4D
             data = f.read()
             f.close()
 
@@ -129,7 +129,7 @@ class Depthmap:
                    depthmap_arr,
                    depth_scale,
                    max_confidence,
-                   matrix,
+                   device_pose,
                    rgb_fpath,
                    rgb_array
                    )
@@ -144,7 +144,7 @@ class Depthmap:
         data = None  # bytes
         depth_scale = 0.001
         max_confidence = 7.0
-        matrix = None
+        device_pose = None
         rgb_fpath = None
         rgb_array = rgb_arr
 
@@ -155,7 +155,7 @@ class Depthmap:
                    depthmap_arr,
                    depth_scale,
                    max_confidence,
-                   matrix,
+                   device_pose,
                    rgb_fpath,
                    rgb_array,
                    )
@@ -201,11 +201,11 @@ class Depthmap:
         if is_google_tango_resolution(self.width, self.height):
             res = [-res[0], -res[1], -res[2]]
 
-        if not self.matrix:
-            logging.warn("Device pose (`matrix`) was not provided.")
+        if not self.device_pose:
+            logging.warn("Device pose matrix was not provided.")
             return res
         try:
-            res = matrix_transform_point(res, self.matrix)
+            res = matrix_transform_point(res, self.device_pose)
             res = [res[0], -res[1], res[2]]
         except NameError:
             pass

--- a/src/common/depthmap_toolkit/depthmap.py
+++ b/src/common/depthmap_toolkit/depthmap.py
@@ -364,22 +364,21 @@ class Depthmap:
         depths = [depth_x_minus, depth_x_plus, depth_y_minus, depth_y_plus, depth_center]
         return sum(depths) / len(depths)
 
-    def convert_3d_to_2d(self, sensor: int, x: float, y: float, depth: float) -> list:  # TODO unused
-        """Convert point in meters into point in pixels
+
+def convert_3d_to_2d(intrinsics: list, x: float, y: float, depth: float, width: int, height: int) -> list:
+    """Convert point in meters into point in pixels
 
         Args:
-            sensor: Tells if this is ToF sensor or RGB sensor
+            intrinsics of sensor: Tells if this is ToF sensor or RGB sensor
             x: X-pos in m
             y: Y-pos in m
             depth: distance from sensor to object at (x, y)
+            width
+            height
 
         Returns:
             tx, ty, depth
         """
-        return convert_3d_to_2d(self.intrinsics[sensor], x, y, depth, self.width, self.height)
-
-
-def convert_3d_to_2d(intrinsics: list, x: float, y: float, depth: float, width: int, height: int) -> list:
     fx = intrinsics[0] * float(width)
     fy = intrinsics[1] * float(height)
     cx = intrinsics[2] * float(width)

--- a/src/common/depthmap_toolkit/depthmap.py
+++ b/src/common/depthmap_toolkit/depthmap.py
@@ -83,11 +83,11 @@ class Depthmap:
         return self.rgb_array is not None
 
     @classmethod
-    def create_from_file(cls,
-                         depthmap_dir: str,
-                         depthmap_fname: str,
-                         rgb_fname: str,
-                         calibration_file: str) -> 'Depthmap':
+    def create_from_zip(cls,
+                        depthmap_dir: str,
+                        depthmap_fname: str,
+                        rgb_fname: str,
+                        calibration_file: str) -> 'Depthmap':
 
         # read depthmap data
         path = extract_depthmap(depthmap_dir, depthmap_fname)

--- a/src/common/depthmap_toolkit/depthmap.py
+++ b/src/common/depthmap_toolkit/depthmap.py
@@ -62,12 +62,12 @@ class Depthmap:
         self.width = width
         self.height = height
         self.data = data
-        self.depthmap_arr = self._parse_data()
-        self.confidence_arr = self._parse_confidence_data()
         self.depth_scale = depth_scale
         self.max_confidence = max_confidence
         self.matrix = matrix
         self.rgb_array = rgb_array
+        self.depthmap_arr = self._parse_data()
+        self.confidence_arr = self._parse_confidence_data()
 
     @property
     def has_rgb(self) -> bool:

--- a/src/common/depthmap_toolkit/depthmap.py
+++ b/src/common/depthmap_toolkit/depthmap.py
@@ -57,7 +57,6 @@ class Depthmap:
             depth_scale,
             max_confidence,
             matrix,
-            rgb_fpath,
             rgb_array):
         self.intrinsics = intrinsics
         self.width = width
@@ -66,7 +65,6 @@ class Depthmap:
         self.depth_scale = depth_scale
         self.max_confidence = max_confidence
         self.matrix = matrix
-        self.rgb_fpath = rgb_fpath
         self.rgb_array = rgb_array
 
     @property
@@ -120,7 +118,6 @@ class Depthmap:
                    depth_scale,
                    max_confidence,
                    matrix,
-                   rgb_fpath,
                    rgb_array
                    )
 
@@ -174,7 +171,6 @@ class Depthmap:
         return res
 
     def detect_child(self, floor: float) -> np.array:
-
         mask, segments = self.detect_objects(floor)
 
         # Select the most focused segment

--- a/src/common/depthmap_toolkit/depthmap.py
+++ b/src/common/depthmap_toolkit/depthmap.py
@@ -62,6 +62,7 @@ class Depthmap:
         self.width = width
         self.height = height
         self.data = data
+        self.depthmap_arr = self.parse_data()
         self.depth_scale = depth_scale
         self.max_confidence = max_confidence
         self.matrix = matrix
@@ -120,6 +121,13 @@ class Depthmap:
                    matrix,
                    rgb_array
                    )
+
+    def parse_data(self) -> np.array:
+        output = np.zeros((self.width, self.height))
+        for x in range(self.width):
+            for y in range(self.height):
+                output[x,y] = self.parse_depth(x, y)
+        return output
 
     def calculate_normal_vector(self, x: float, y: float) -> list:
         """Calculate normal vector of depthmap point based on neighbors"""

--- a/src/common/depthmap_toolkit/depthmap.py
+++ b/src/common/depthmap_toolkit/depthmap.py
@@ -311,6 +311,10 @@ class Depthmap:
 
     def parse_depth_smoothed(self, tx: int, ty) -> float:
         """Get average depth value from neighboring pixels"""
+        if tx - 1 < 0 or ty - 1 < 0:
+            return 0.
+        if tx + 1 >= self.width or ty + 1 >= self.height:
+            return 0.
 
         # Get all neighbor depths
         depth_center = self.depthmap_arr[tx, ty]
@@ -321,7 +325,7 @@ class Depthmap:
 
         # Ensure the depth is defined
         if 0 in [depth_center, depth_x_plus, depth_y_minus, depth_y_plus]:
-            return 0
+            return 0.
 
         # Average the depth value
         depths = [depth_x_minus, depth_x_plus, depth_y_minus, depth_y_plus, depth_center]

--- a/src/common/depthmap_toolkit/depthmap.py
+++ b/src/common/depthmap_toolkit/depthmap.py
@@ -45,6 +45,7 @@ class Depthmap:
                               The ZIP-file header contains this pose
                               - `matrix` is a list representation of this pose
                               - can be used to project into a different space
+        rgb_fpath (str): Path to RGB file (e.g. to the jpg)
         rgb_array (np.array): RGB data
     """
 
@@ -58,6 +59,7 @@ class Depthmap:
             depth_scale: float,
             max_confidence: float,
             matrix: List[float],
+            rgb_fpath: Path,
             rgb_array: np.array):
         """Constructor
 
@@ -69,6 +71,7 @@ class Depthmap:
         self.depth_scale = depth_scale
         self.max_confidence = max_confidence
         self.matrix = matrix
+        self.rgb_fpath = rgb_fpath
         self.rgb_array = rgb_array
         assert depthmap_arr is None or data is None
         self.depthmap_arr = self._parse_depth_data(data) if data else depthmap_arr
@@ -107,7 +110,7 @@ class Depthmap:
 
         # read rgb data
         if rgb_fname:
-            rgb_fpath = depthmap_dir + '/rgb/' + rgb_fname
+            rgb_fpath = Path(depthmap_dir) / 'rgb' / rgb_fname
             pil_im = Image.open(rgb_fpath)
             pil_im = pil_im.resize((width, height), Image.ANTIALIAS)
             rgb_array = np.asarray(pil_im)
@@ -127,6 +130,7 @@ class Depthmap:
                    depth_scale,
                    max_confidence,
                    matrix,
+                   rgb_fpath,
                    rgb_array
                    )
 
@@ -141,6 +145,7 @@ class Depthmap:
         depth_scale = 0.001
         max_confidence = 7.0
         matrix = None
+        rgb_fpath = None
         rgb_array = rgb_arr
 
         return cls(intrinsics,
@@ -151,6 +156,7 @@ class Depthmap:
                    depth_scale,
                    max_confidence,
                    matrix,
+                   rgb_fpath,
                    rgb_array,
                    )
 

--- a/src/common/depthmap_toolkit/depthmap.py
+++ b/src/common/depthmap_toolkit/depthmap.py
@@ -127,14 +127,14 @@ class Depthmap:
         output = np.zeros((self.width, self.height))
         for x in range(self.width):
             for y in range(self.height):
-                output[x,y] = self._parse_depth(x, y)
+                output[x, y] = self._parse_depth(x, y)
         return output
 
     def _parse_confidence_data(self) -> np.array:
         output = np.zeros((self.width, self.height))
         for x in range(self.width):
             for y in range(self.height):
-                output[x,y] = self._parse_confidence(x, y)
+                output[x, y] = self._parse_confidence(x, y)
         return output
 
     def calculate_normal_vector(self, x: float, y: float) -> list:

--- a/src/common/depthmap_toolkit/depthmap.py
+++ b/src/common/depthmap_toolkit/depthmap.py
@@ -41,8 +41,9 @@ class Depthmap:
         max_confidence (float): Confidence is amount of IR light reflected
                                 (e.g. 0 to 255 in Lenovo, new standard is 0 to 7)
                                 This is actually an int.
-        matrix (List[float]): Header contains a pose (= position and rotation)
-                              - matrix is a list representation of this pose
+        matrix (List[float]): The device pose (= position and rotation)
+                              The ZIP-file header contains this pose
+                              - `matrix` is a list representation of this pose
                               - can be used to project into a different space
         rgb_array (np.array): RGB data
     """
@@ -134,13 +135,12 @@ class Depthmap:
                           depthmap_arr: np.array,
                           rgb_arr: np.array,
                           calibration_file: str) -> 'Depthmap':
-        matrix = IDENTITY_MATRIX_4D  # TODO check with Lubos
         intrinsics = parse_calibration(calibration_file)
-
         height, width = depthmap_arr.shape
         data = None  # bytes
         depth_scale = 0.001
         max_confidence = 7.0
+        matrix = None
         rgb_array = rgb_arr
 
         return cls(intrinsics,
@@ -195,6 +195,9 @@ class Depthmap:
         if is_google_tango_resolution(self.width, self.height):
             res = [-res[0], -res[1], -res[2]]
 
+        if not self.matrix:
+            logging.warn("Device pose (`matrix`) was not provided.")
+            return res
         try:
             res = matrix_transform_point(res, self.matrix)
             res = [res[0], -res[1], res[2]]

--- a/src/common/depthmap_toolkit/depthmap.py
+++ b/src/common/depthmap_toolkit/depthmap.py
@@ -191,11 +191,10 @@ class Depthmap:
         if not res:
             return res
 
-        # special case for Google Tango devices with different rotation
-        if self.width == 180 and self.height == 135:
-            res = [res[0], -res[1], res[2]]
-        else:
-            res = [-res[0], res[1], res[2]]
+        res = [-res[0], res[1], res[2]]
+        if is_google_tango_resolution(self.width, self.height):
+            res = [-res[0], -res[1], -res[2]]
+
         try:
             res = matrix_transform_point(res, self.matrix)
             res = [res[0], -res[1], res[2]]
@@ -406,3 +405,8 @@ def parse_calibration(filepath: str) -> List[List[float]]:
             intrinsic = parse_numbers(line_with_numbers)
             calibration.append(intrinsic)
     return calibration
+
+
+def is_google_tango_resolution(width, height):
+    """Check for special case for Google Tango devices with different rotation"""
+    return width == 180 and height == 135

--- a/src/common/depthmap_toolkit/depthmap_utils.py
+++ b/src/common/depthmap_toolkit/depthmap_utils.py
@@ -76,13 +76,13 @@ def matrix_calculate(position: List[float], rotation: List[float]) -> List[float
     return output
 
 
-def matrix_transform_point(point: List[float], matrix: List[float]) -> List[float]:
-    """Transformation of point by matrix"""
+def matrix_transform_point(point: List[float], device_pose: List[float]) -> List[float]:
+    """Transformation of point by device pose matrix"""
     output = [0, 0, 0, 1]
-    output[0] = point[0] * matrix[0] + point[1] * matrix[4] + point[2] * matrix[8] + matrix[12]
-    output[1] = point[0] * matrix[1] + point[1] * matrix[5] + point[2] * matrix[9] + matrix[13]
-    output[2] = point[0] * matrix[2] + point[1] * matrix[6] + point[2] * matrix[10] + matrix[14]
-    output[3] = point[0] * matrix[3] + point[1] * matrix[7] + point[2] * matrix[11] + matrix[15]
+    output[0] = point[0] * device_pose[0] + point[1] * device_pose[4] + point[2] * device_pose[8] + device_pose[12]
+    output[1] = point[0] * device_pose[1] + point[1] * device_pose[5] + point[2] * device_pose[9] + device_pose[13]
+    output[2] = point[0] * device_pose[2] + point[1] * device_pose[6] + point[2] * device_pose[10] + device_pose[14]
+    output[3] = point[0] * device_pose[3] + point[1] * device_pose[7] + point[2] * device_pose[11] + device_pose[15]
 
     output[0] /= abs(output[3])
     output[1] /= abs(output[3])

--- a/src/common/depthmap_toolkit/exporter.py
+++ b/src/common/depthmap_toolkit/exporter.py
@@ -27,7 +27,7 @@ def export_obj(filename: str,
     if dmap.has_rgb:
         with open(material, 'w') as f:
             f.write('newmtl default\n')
-            f.write('map_Kd ../' + dmap.rgb_fpath + '\n')
+            f.write(f'map_Kd ../{str(dmap.rgb_fpath)}\n')
 
     with open(filename, 'w') as f:
         if dmap.has_rgb:

--- a/src/common/depthmap_toolkit/exporter.py
+++ b/src/common/depthmap_toolkit/exporter.py
@@ -35,7 +35,7 @@ def export_obj(filename: str,
             f.write('usemtl default\n')
         for x in range(2, dmap.width - 2):
             for y in range(2, dmap.height - 2):
-                depth = dmap.parse_depth(x, y)
+                depth = dmap.depthmap_arr[x, y]
                 if not depth:
                     continue
                 res = dmap.convert_2d_to_3d_oriented(1, x, y, depth)
@@ -57,10 +57,10 @@ def _do_triangulation(dmap: Depthmap, indices, filehandle):
     for x in range(2, dmap.width - 2):
         for y in range(2, dmap.height - 2):
             # get depth of all points of 2 potential triangles
-            d00 = dmap.parse_depth(x, y)
-            d10 = dmap.parse_depth(x + 1, y)
-            d01 = dmap.parse_depth(x, y + 1)
-            d11 = dmap.parse_depth(x + 1, y + 1)
+            d00 = dmap.depthmap_arr[x, y]
+            d10 = dmap.depthmap_arr[x + 1, y]
+            d01 = dmap.depthmap_arr[x, y + 1]
+            d11 = dmap.depthmap_arr[x + 1, y + 1]
 
             # check if first triangle points have existing indices
             if indices[x][y] > 0 and indices[x + 1][y] > 0 and indices[x][y + 1] > 0:
@@ -107,13 +107,13 @@ def export_pcd(filename: str, dmap: Depthmap):
 
         for x in range(2, dmap.width - 2):
             for y in range(2, dmap.height - 2):
-                depth = dmap.parse_depth(x, y)
+                depth = dmap.depthmap_arr[x, y]
                 if not depth:
                     continue
                 res = dmap.convert_2d_to_3d(1, x, y, depth)
                 if not res:
                     continue
-                confidence = dmap.parse_confidence(x, y)
+                confidence = dmap.confidence_arr[x, y]
                 f.write(str(-res[0]) + ' ' + str(res[1]) + ' ' + str(res[2]) + ' ' + str(confidence) + '\n')
         logging.info('Pointcloud exported into %s', filename)
 
@@ -122,7 +122,7 @@ def _get_count(dmap: Depthmap) -> int:
     count = 0
     for x in range(2, dmap.width - 2):
         for y in range(2, dmap.height - 2):
-            depth = dmap.parse_depth(x, y)
+            depth = dmap.depthmap_arr[x, y]
             if not depth:
                 continue
             res = dmap.convert_2d_to_3d(1, x, y, depth)

--- a/src/common/depthmap_toolkit/pcd2depth.py
+++ b/src/common/depthmap_toolkit/pcd2depth.py
@@ -27,7 +27,7 @@ def parse_pcd(filepath: str) -> List[List[float]]:
     return data
 
 
-def process(calibration, pcd_fpath: str, width: int, height: int):
+def process(calibration, pcd_fpath: str, width: int, height: int) -> np.array:
     # Convert to depthmap
     points = parse_pcd(pcd_fpath)
     output = np.zeros((width, height, 3))
@@ -36,20 +36,20 @@ def process(calibration, pcd_fpath: str, width: int, height: int):
         x = int(width - v[0] - 1)
         y = int(height - v[1] - 1)
         if x >= 0 and y >= 0 and x < width and y < height:
-            output[x][y][0] = p[3]
-            output[x][y][2] = p[2]
+            output[x, y, 0] = p[3]
+            output[x, y, 2] = p[2]
     return output
 
 
-def write_depthmap(output_depth_fpath: str, depthmap, width: int, height: int):
+def write_depthmap(output_depth_fpath: str, depthmap: np.array, width: int, height: int):
     # Write depthmap
     with open('data', 'wb') as f:
         header_str = str(width) + 'x' + str(height) + '_0.001_255\n'
         f.write(header_str.encode(ENCODING))
         for y in range(height):
             for x in range(width):
-                depth = int(depthmap[x][y][2] * 1000)
-                confidence = int(depthmap[x][y][0] * 255)
+                depth = int(depthmap[x, y, 2] * 1000)
+                confidence = int(depthmap[x, y, 0] * 255)
                 depth_byte = chr(int(depth / 256)).encode(ENCODING)
                 depth_byte2 = chr(depth % 256).encode(ENCODING)
                 confidence_byte = chr(confidence).encode(ENCODING)

--- a/src/common/depthmap_toolkit/scan_toolkit.ipynb
+++ b/src/common/depthmap_toolkit/scan_toolkit.ipynb
@@ -112,7 +112,7 @@
    "source": [
     "dmaps, dmaps_visualizations = [], []\n",
     "for depthmap_fname, rgb_fname in tqdm(list(zip(depthmap_fnames, rgb_fnames))):\n",
-    "    dmap = Depthmap.create_from_file(str(depthmap_dir), str(depthmap_fname), str(rgb_fname), str(calibration_file))\n",
+    "    dmap = Depthmap.create_from_zip(str(depthmap_dir), str(depthmap_fname), str(rgb_fname), str(calibration_file))\n",
     "    dmaps.append(dmap)\n",
     "    dmaps_visualizations.append(render_plot(dmap))  # takes 5 seconds each time"
    ]

--- a/src/common/depthmap_toolkit/scan_toolkit.ipynb
+++ b/src/common/depthmap_toolkit/scan_toolkit.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -30,20 +30,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "PosixPath('/Users/markus/Development/cgm/cgm-ml/src/common/depthmap_toolkit')"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "TOOLKIT_DIR = Path(os.getcwd()).absolute()\n",
     "TOOLKIT_DIR"
@@ -51,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -63,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -84,7 +73,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,20 +84,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "  0%|          | 0/3 [00:00<?, ?it/s]2021-06-18 18:31:17,433 - INFO - height=0.435327m - /Users/markus/Development/cgm/cgm-ml/src/common/depthmap_toolkit/visualisation.py: line 99\n",
-      " 33%|███▎      | 1/3 [00:06<00:13,  6.85s/it]2021-06-18 18:31:23,989 - INFO - height=0.433781m - /Users/markus/Development/cgm/cgm-ml/src/common/depthmap_toolkit/visualisation.py: line 99\n",
-      " 67%|██████▋   | 2/3 [00:13<00:06,  6.76s/it]2021-06-18 18:31:30,489 - INFO - height=0.434632m - /Users/markus/Development/cgm/cgm-ml/src/common/depthmap_toolkit/visualisation.py: line 99\n",
-      "100%|██████████| 3/3 [00:19<00:00,  6.63s/it]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "dmaps, dmaps_visualizations = [], []\n",
     "for depthmap_fname, rgb_fname in tqdm(list(zip(depthmap_fnames, rgb_fnames))):\n",
@@ -119,24 +97,62 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ae27979165684b0a8c0dea6db9a1e458",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "VBox(children=(IntSlider(value=0, description='artifact_idx', max=2), Output()), layout=Layout(width='50%'))"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
+   "source": [
+    "dmap = dmaps[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dmap.intrinsics\n",
+    "dmap.width\n",
+    "dmap.height\n",
+    "dmap.data\n",
+    "dmap.depth_scale\n",
+    "dmap.max_confidence\n",
+    "# dmap.matrix\n",
+    "# dmap.rgb_fpath\n",
+    "# dmap.rgb_array"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dmap.width, dmap.height"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(dmap.data) / 240 / 180"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dmap.parse_confidence(1,2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Easy visualization\n",
     "\n",
@@ -151,7 +167,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -193,59 +209,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Use the slider to navigate between artifacts, click the button to export the current image\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "442fab4b18d64569a84349e8cb8a9f78",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "IntSlider(value=0, description='artifact_idx', max=2)"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0fb6892d158445c5b7b24c6f2061da0d",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Output()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "279d485779144f07bb30a522f38f6ce5",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HBox(children=(Button(description='Export OBJ!', style=ButtonStyle()), Text(value='')), layout=Layout(width='5…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"Use the slider to navigate between artifacts, click the button to export the current image\")\n",
     "viz = Viz(dmaps=dmaps, dmaps_visualizations=dmaps_visualizations)"
@@ -263,7 +229,73 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "dmap = dmaps[0]\n",
+    "floor = dmap.get_floor_level()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mask = dmap.detect_child(floor)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from constants import MASK_CHILD"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mask_child = (mask==MASK_CHILD).astype(np.int)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.imshow(mask_child, cmap='gray');"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.imshow(mask, cmap='gray', vmin=1, vmax=3);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mask.max()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO load RGBD dataset"
+   ]
   }
  ],
  "metadata": {
@@ -275,9 +307,8 @@
    "name": "python3"
   },
   "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
+   "name": "python3",
+   "display_name": "Python 3.7.5 64-bit ('env_p_3': virtualenvwrapper)"
   },
   "language_info": {
    "codemirror_mode": {

--- a/src/common/depthmap_toolkit/scan_toolkit.ipynb
+++ b/src/common/depthmap_toolkit/scan_toolkit.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -30,9 +30,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "PosixPath('/Users/markus/Development/cgm/cgm-ml/src/common/depthmap_toolkit')"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 35
+    }
+   ],
    "source": [
     "TOOLKIT_DIR = Path(os.getcwd()).absolute()\n",
     "TOOLKIT_DIR"
@@ -40,7 +51,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -52,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -73,7 +84,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -84,68 +95,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 39,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "text": [
+      "  0%|          | 0/3 [00:00<?, ?it/s]2021-07-19 16:10:59,015 - INFO - height=0.433028m - /Users/markus/Development/cgm/cgm-ml/src/common/depthmap_toolkit/visualisation.py: line 164\n",
+      " 33%|███▎      | 1/3 [00:10<00:20, 10.22s/it]2021-07-19 16:11:08,320 - INFO - height=0.427724m - /Users/markus/Development/cgm/cgm-ml/src/common/depthmap_toolkit/visualisation.py: line 164\n",
+      " 67%|██████▋   | 2/3 [00:19<00:09,  9.94s/it]2021-07-19 16:11:17,956 - INFO - height=0.427468m - /Users/markus/Development/cgm/cgm-ml/src/common/depthmap_toolkit/visualisation.py: line 164\n",
+      "100%|██████████| 3/3 [00:29<00:00,  9.72s/it]\n"
+     ]
+    }
+   ],
    "source": [
     "dmaps, dmaps_visualizations = [], []\n",
     "for depthmap_fname, rgb_fname in tqdm(list(zip(depthmap_fnames, rgb_fnames))):\n",
     "    dmap = Depthmap.create_from_file(str(depthmap_dir), str(depthmap_fname), str(rgb_fname), str(calibration_file))\n",
     "    dmaps.append(dmap)\n",
     "    dmaps_visualizations.append(render_plot(dmap))  # takes 5 seconds each time"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "dmap = dmaps[0]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "dmap.intrinsics\n",
-    "dmap.width\n",
-    "dmap.height\n",
-    "dmap.data\n",
-    "dmap.depth_scale\n",
-    "dmap.max_confidence\n",
-    "# dmap.matrix\n",
-    "# dmap.rgb_fpath\n",
-    "# dmap.rgb_array"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "dmap.width, dmap.height"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "len(dmap.data) / 240 / 180"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "dmap.confidence_arr[1,2]"
    ]
   },
   {
@@ -223,79 +192,6 @@
    "metadata": {},
    "outputs": [],
    "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "dmap = dmaps[0]\n",
-    "floor = dmap.get_floor_level()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "mask = dmap.detect_child(floor)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from constants import MASK_CHILD"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "mask_child = (mask==MASK_CHILD).astype(np.int)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plt.imshow(mask_child, cmap='gray');"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plt.imshow(mask, cmap='gray', vmin=1, vmax=3);"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "mask.max()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# TODO load RGBD dataset"
-   ]
   }
  ],
  "metadata": {

--- a/src/common/depthmap_toolkit/scan_toolkit.ipynb
+++ b/src/common/depthmap_toolkit/scan_toolkit.ipynb
@@ -145,7 +145,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dmap.parse_confidence(1,2)"
+    "dmap.confidence_arr[1,2]"
    ]
   },
   {

--- a/src/common/depthmap_toolkit/tests/test_depthmap.py
+++ b/src/common/depthmap_toolkit/tests/test_depthmap.py
@@ -13,7 +13,7 @@ def test_depthmap():
     rgb_fname = 'rgb_dog_1622182020448_100_282.jpg'
     calibration_file = str(TOOLKIT_DIR / 'huawei_p40pro' / 'camera_calibration.txt')
 
-    dmap = Depthmap.create_from_file(depthmap_dir, depthmap_fname, rgb_fname, calibration_file)
+    dmap = Depthmap.create_from_zip(depthmap_dir, depthmap_fname, rgb_fname, calibration_file)
 
     assert dmap.width == 240
     assert dmap.height == 180
@@ -43,7 +43,7 @@ def test_get_highest_point():
     depthmap_fname = 'depth_dog_1622182020448_100_282.depth'
     rgb_fname = 'rgb_dog_1622182020448_100_282.jpg'
     calibration_file = str(TOOLKIT_DIR / 'huawei_p40pro' / 'camera_calibration.txt')
-    dmap = Depthmap.create_from_file(depthmap_dir, depthmap_fname, rgb_fname, calibration_file)
+    dmap = Depthmap.create_from_zip(depthmap_dir, depthmap_fname, rgb_fname, calibration_file)
 
     # Find top of the object
     floor = dmap.get_floor_level()

--- a/src/common/depthmap_toolkit/tests/test_visualisation.py
+++ b/src/common/depthmap_toolkit/tests/test_visualisation.py
@@ -16,7 +16,7 @@ def test_blur_face():
     depthmap_fname = 'depth_dog_1622182020448_100_282.depth'
     rgb_fname = 'rgb_dog_1622182020448_100_282.jpg'
     calibration_file = str(TOOLKIT_DIR / 'huawei_p40pro' / 'camera_calibration.txt')
-    dmap = Depthmap.create_from_file(depthmap_dir, depthmap_fname, rgb_fname, calibration_file)
+    dmap = Depthmap.create_from_zip(depthmap_dir, depthmap_fname, rgb_fname, calibration_file)
 
     # Find top of the object
     floor = dmap.get_floor_level()

--- a/src/common/depthmap_toolkit/toolkit.py
+++ b/src/common/depthmap_toolkit/toolkit.py
@@ -83,7 +83,7 @@ def show(depthmap_dir: str, calibration_file: str):
     global DMAP
     fig.canvas.manager.set_window_title(depth_filenames[INDEX])
     rgb_filename = rgb_filenames[INDEX] if rgb_filenames else 0
-    DMAP = Depthmap.create_from_file(depthmap_dir, depth_filenames[INDEX], rgb_filename, calibration_file)
+    DMAP = Depthmap.create_from_zip(depthmap_dir, depth_filenames[INDEX], rgb_filename, calibration_file)
 
     angle = DMAP.get_angle_between_camera_and_floor()
     logging.info('angle between camera and floor is %f', angle)

--- a/src/common/depthmap_toolkit/toolkit.py
+++ b/src/common/depthmap_toolkit/toolkit.py
@@ -34,7 +34,7 @@ def onclick(event):
         x = int(event.ydata)
         y = DMAP.height - int(event.xdata) - 1
         if x > 1 and y > 1 and x < DMAP.width - 2 and y < DMAP.height - 2:
-            depth = DMAP.parse_depth(x, y)
+            depth = DMAP.depthmap_arr[x, y]
             if depth:
                 res = DMAP.convert_2d_to_3d(1, x, y, depth)
                 if res:

--- a/src/common/depthmap_toolkit/visualisation.py
+++ b/src/common/depthmap_toolkit/visualisation.py
@@ -53,10 +53,10 @@ def blur_face(data: np.array, subplot: int, highest: list, dmap: Depthmap) -> np
                     if not (0 < tx < dmap.width and 0 < ty < dmap.height):
                         continue
                     index = subplot * dmap.height + dmap.height - ty - 1
-                    pixel = pixel + data[tx][index][0]
+                    pixel = pixel + data[tx, index, 0]
                     count = count + 1
             index = subplot * dmap.height + dmap.height - y - 1
-            output[x][index] = pixel / count
+            output[x, index] = pixel / count
 
     return output
 
@@ -67,9 +67,9 @@ def render_confidence(output: np.array,
     for x in range(dmap.width):
         for y in range(dmap.height):
             index = subplot * dmap.height + dmap.height - y - 1
-            output[x][index][:] = dmap.confidence_arr[x, y]
-            if output[x][index][0] == 0:
-                output[x][index][:] = 1
+            output[x, index, :] = dmap.confidence_arr[x, y]
+            if output[x, index, 0] == 0:
+                output[x, index, :] = 1
 
 
 def render_depth(output: np.array,
@@ -81,7 +81,7 @@ def render_depth(output: np.array,
             if not depth:
                 continue
             index = subplot * dmap.height + dmap.height - y - 1
-            output[x][index] = min(max(0, 1.0 - min(depth / 2.0, 1.0)), 1)
+            output[x, index] = min(max(0, 1.0 - min(depth / 2.0, 1.0)), 1)
 
 
 def render_normal(output: np.array,
@@ -91,9 +91,9 @@ def render_normal(output: np.array,
         for y in range(dmap.height):
             normal = dmap.calculate_normal_vector(x, y)
             index = subplot * dmap.height + dmap.height - y - 1
-            output[x][index][0] = abs(normal[0])
-            output[x][index][1] = abs(normal[1])
-            output[x][index][2] = abs(normal[2])
+            output[x, index, 0] = abs(normal[0])
+            output[x, index, 1] = abs(normal[1])
+            output[x, index, 2] = abs(normal[2])
 
 
 def render_rgb(output: np.array,
@@ -102,9 +102,9 @@ def render_rgb(output: np.array,
     for x in range(dmap.width):
         for y in range(dmap.height):
             index = subplot * dmap.height + dmap.height - y - 1
-            output[x][index][0] = dmap.rgb_array[y][x][0] / 255.0
-            output[x][index][1] = dmap.rgb_array[y][x][1] / 255.0
-            output[x][index][2] = dmap.rgb_array[y][x][2] / 255.0
+            output[x, index, 0] = dmap.rgb_array[y, x, 0] / 255.0
+            output[x, index, 1] = dmap.rgb_array[y, x, 1] / 255.0
+            output[x, index, 2] = dmap.rgb_array[y, x, 2] / 255.0
 
 
 def render_segmentation(output: np.array,
@@ -129,20 +129,20 @@ def render_segmentation(output: np.array,
             vertical = (vertical_x + vertical_z) / 2.0
             index = subplot * dmap.height + dmap.height - y - 1
             if mask[x, y] == MASK_CHILD:
-                output[x][index][0] = horizontal / (depth * depth)
-                output[x][index][1] = horizontal / (depth * depth)
+                output[x, index, 0] = horizontal / (depth * depth)
+                output[x, index, 1] = horizontal / (depth * depth)
             elif abs(normal[1]) < 0.5:
-                output[x][index][0] = horizontal / (depth * depth)
+                output[x, index, 0] = horizontal / (depth * depth)
             elif abs(normal[1]) > 0.5:
                 if abs(point[1] - floor) < 0.1:
-                    output[x][index][2] = vertical / (depth * depth)
+                    output[x, index, 2] = vertical / (depth * depth)
                 else:
-                    output[x][index][1] = vertical / (depth * depth)
+                    output[x, index, 1] = vertical / (depth * depth)
 
             # ensure pixel clipping
-            output[x][index][0] = min(max(0, output[x][index][0]), 1)
-            output[x][index][1] = min(max(0, output[x][index][1]), 1)
-            output[x][index][2] = min(max(0, output[x][index][2]), 1)
+            output[x, index, 0] = min(max(0, output[x, index, 0]), 1)
+            output[x, index, 1] = min(max(0, output[x, index, 1]), 1)
+            output[x, index, 2] = min(max(0, output[x, index, 2]), 1)
 
 
 def render_plot(dmap: Depthmap) -> np.array:

--- a/src/common/depthmap_toolkit/visualisation.py
+++ b/src/common/depthmap_toolkit/visualisation.py
@@ -128,7 +128,7 @@ def render_segmentation(output: np.array,
             vertical_z = (point[2] % PATTERN_LENGTH_IN_METERS) / PATTERN_LENGTH_IN_METERS
             vertical = (vertical_x + vertical_z) / 2.0
             index = subplot * dmap.height + dmap.height - y - 1
-            if mask[x][y] == MASK_CHILD:
+            if mask[x, y] == MASK_CHILD:
                 output[x][index][0] = horizontal / (depth * depth)
                 output[x][index][1] = horizontal / (depth * depth)
             elif abs(normal[1]) < 0.5:

--- a/src/common/depthmap_toolkit/visualisation.py
+++ b/src/common/depthmap_toolkit/visualisation.py
@@ -36,7 +36,7 @@ def blur_face(data: np.array, subplot: int, highest: list, dmap: Depthmap) -> np
         for y in range(dmap.height):
 
             # count distance from the highest child point
-            depth = dmap.parse_depth(x, y)
+            depth = dmap.depthmap_arr[x, y]
             if not depth:
                 continue
             point = dmap.convert_2d_to_3d_oriented(1, x, y, depth)
@@ -67,7 +67,7 @@ def render_confidence(output: np.array,
     for x in range(dmap.width):
         for y in range(dmap.height):
             index = subplot * dmap.height + dmap.height - y - 1
-            output[x][index][:] = dmap.parse_confidence(x, y)
+            output[x][index][:] = dmap.confidence_arr[x, y]
             if output[x][index][0] == 0:
                 output[x][index][:] = 1
 
@@ -77,7 +77,7 @@ def render_depth(output: np.array,
                  dmap: Depthmap):
     for x in range(dmap.width):
         for y in range(dmap.height):
-            depth = dmap.parse_depth(x, y)
+            depth = dmap.depthmap_arr[x, y]
             if not depth:
                 continue
             index = subplot * dmap.height + dmap.height - y - 1
@@ -116,7 +116,7 @@ def render_segmentation(output: np.array,
         for y in range(dmap.height):
 
             # get depth value
-            depth = dmap.parse_depth(x, y)
+            depth = dmap.depthmap_arr[x, y]
             if not depth:
                 continue
 

--- a/src/common/reliability/background_segm/tests/test_maskrcnn_resizeimage.py
+++ b/src/common/reliability/background_segm/tests/test_maskrcnn_resizeimage.py
@@ -29,5 +29,5 @@ def test_maskrcnn_resizeimage():
     assert height > 100
 
     # Check the pixel values of the mask
-    assert mask[0][0] == 0  # Background (0) is in the corner
-    assert mask[int(height / 2)][int(width / 2)] == 1  # Child (1) is in the middle
+    assert mask[0, 0] == 0  # Background (0) is in the corner
+    assert mask[int(height / 2), int(width / 2)] == 1  # Child (1) is in the middle


### PR DESCRIPTION
**CR:** https://dev.azure.com/cgmorg/ChildGrowthMonitor/_workitems/edit/1543

**Changes:**
- Prevent redundant `parse_depth()` calculation by maintaining an np.array `depthmap_arr`
- Improve Depthmap constructor interface: now support `create_from_file` (ZIP) and `create_from_array` (np.array)
- Introduce `Depthmap.create_from_array()`
- Introduce `EDA_RGBD_segmentationCV.ipynb` to analyze RGBD pickle files with depthmap toolkit
- Fix: toolkit fails to ignore hidden files like `.DS_Store`
- Introduce `is_google_tango_resolution()`
- Remove unused `convert_3d_to_2d`
- Use cgm-ml/data/export as default export directory instead of using code directories
- Making export more robust
- Making toolkit.py callable from cgm-ml dir: `python src/common/depthmap_toolkit/toolkit.py src/common/depthmap_toolkit/tests/huawei_p40pro src/common/depthmap_toolkit/tests/huawei_p40pro/camera_calibration.txt` (no need to `cd src/common/depthmap_toolkit` anymore)

**How Has This Been Tested?**
- existing unit tests still run
- running depthmap toolkit locally still works

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests
- [x] New and existing unit tests pass locally with my changes
- [x] My Code is review by 1 People
