### PR TITLE
updated the pickle output_path

### DIFF
--- a/cgmml/common/data_utilities/mlpipeline_utils.py
+++ b/cgmml/common/data_utilities/mlpipeline_utils.py
@@ -149,7 +149,8 @@ class ArtifactProcessor:
         scan_id = artifact_dict['scan_id']
         scan_step = artifact_dict['scan_step']
         order_number = artifact_dict['order_number']
-        pickle_output_path = f"scans/{scan_id}/{scan_step}/pc_{scan_id}_{timestamp}_{scan_step}_{order_number}.p"
+        person_id = artifact_dict['person_id']
+        pickle_output_path = f"scans/{person_id}/{scan_step}/pc_{scan_id}_{timestamp}_{scan_step}_{order_number}.p"
 
         # Write into pickle
         pickle_output_full_path = f"{self.output_dir}/{pickle_output_path}"

--- a/cgmml/common/data_utilities/tests/test_mlpipeline_utils.py
+++ b/cgmml/common/data_utilities/tests/test_mlpipeline_utils.py
@@ -17,6 +17,7 @@ ARTIFACT_DICT = {
     'weight': 20.555,
     'muac': 10.0,
     'order_number': 3,
+    'person_id': '09495c00-ff19-11eb-95bd-6fef000028be'
 }
 
 
@@ -34,7 +35,7 @@ def test_artifact_processor_depthmap():
             / 'tests'
             / 'pickle_files'
             / 'scans'
-            / 'c571de02-a723-11eb-8845-bb6589a1fbe8'
+            / '09495c00-ff19-11eb-95bd-6fef000028be'
             / '102'
             / 'pc_c571de02-a723-11eb-8845-bb6589a1fbe8_2021-04-22_13-34-33-302557_102_3.p')
         assert pickle_path_expected.split('/')[-4:] == processed_fname.split('/')[-4:]
@@ -68,7 +69,7 @@ def test_artifact_processor_rgbd():
             / 'tests'
             / 'pickle_files'
             / 'scans'
-            / 'c571de02-a723-11eb-8845-bb6589a1fbe8'
+            / '09495c00-ff19-11eb-95bd-6fef000028be'
             / '102'
             / 'pc_c571de02-a723-11eb-8845-bb6589a1fbe8_2021-04-22_13-34-33-302557_102_3.p')
         assert pickle_path_expected.split('/')[-4:] == processed_fname.split('/')[-4:]


### PR DESCRIPTION
# Description

We want to change the directory structure of the pickle files created in datasets. We replace scan_id in directory by person_id.

User story # (US link)
https://dev.azure.com/cgmorg/ChildGrowthMonitor/_workitems/edit/1507

# How Has This Been Tested?

- [x] unit tests run successfully


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests
- [x] New and existing unit tests pass locally with my changes
- [ ] My Code is review by 1 People
